### PR TITLE
Provide a root HTTP handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,6 +60,15 @@ func main() {
 		log.Fatal("Either -master or -slave is required")
 	}
 
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+            <head><title>Mesos Exporter</title></head>
+            <body>
+            <h1>Mesos Exporter</h1>
+            <p><a href="/metrics">Metrics</a></p>
+            </body>
+            </html>`))
+	})
 	http.Handle("/metrics", prometheus.Handler())
 	if err := http.ListenAndServe(*addr, nil); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Prometheus exporters typically have an HTTP handler for "/". I've added a handler here to:

1. Make the exporter more predictable
2. Provide a route for service/health checks that doesn't have side-effects (e.g, scrape state.json)