### PR TITLE
Add option to ignore task_state_time events

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	masterURL := fs.String("master", "", "Expose metrics from master running on this URL")
 	slaveURL := fs.String("slave", "", "Expose metrics from slave running on this URL")
 	timeout := fs.Duration("timeout", 5*time.Second, "Master polling timeout")
-	ignoreFrameworkTasks := fs.Bool("ignoreFrameworkTasks", false, "Don't export task_state_time metric");
+	ignoreCompletedFrameworkTasks := fs.Bool("ignoreCompletedFrameworkTasks", false, "Don't export task_state_time metric");
 
 	fs.Parse(os.Args[1:])
 	if *masterURL != "" && *slaveURL != "" {
@@ -52,7 +52,7 @@ func main() {
 		for _, f := range []func(*httpClient) prometheus.Collector{
 			newMasterCollector,
 			func(c *httpClient) prometheus.Collector {
-				return newMasterStateCollector(c, *ignoreFrameworkTasks)
+				return newMasterStateCollector(c, *ignoreCompletedFrameworkTasks)
 			},
 		} {
 			c := f(mkHttpClient(*masterURL, *timeout, auth));

--- a/master_state.go
+++ b/master_state.go
@@ -62,160 +62,165 @@ type (
 	}
 )
 
-func newMasterStateCollector(httpClient *httpClient) prometheus.Collector {
+func newMasterStateCollector(httpClient *httpClient, ignoreFrameworkTasks bool) prometheus.Collector {
 	labels := []string{"slave"}
+	metrics := map[prometheus.Collector]func(*state, prometheus.Collector){
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Total slave CPUs (fractional)",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "cpus",
+		}, labels): func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Total.CPUs)
+			}
+		},
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Used slave CPUs (fractional)",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "cpus_used",
+		}, labels): func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Used.CPUs)
+			}
+		},
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Unreserved slave CPUs (fractional)",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "cpus_unreserved",
+		}, labels): func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Unreserved.CPUs)
+			}
+		},
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Total slave memory in bytes",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "mem_bytes",
+		}, labels): func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Total.Mem * 1024)
+			}
+		},
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Used slave memory in bytes",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "mem_used_bytes",
+		}, labels): func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Used.Mem * 1024)
+			}
+		},
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Unreserved slave memory in bytes",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "mem_unreserved_bytes",
+		}, labels): func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Unreserved.Mem * 1024)
+			}
+		},
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Total slave disk space in bytes",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "disk_bytes",
+		}, labels): func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Total.Disk * 1024)
+			}
+		},
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Used slave disk space in bytes",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "disk_used_bytes",
+		}, labels): func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Used.Disk * 1024)
+			}
+		},
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Unreserved slave disk in bytes",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "disk_unreserved_bytes",
+		}, labels): func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Unreserved.Disk * 1024)
+			}
+		},
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Total slave ports",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "ports",
+		}, labels): func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				size := s.Total.Ports.size()
+				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(float64(size))
+			}
+		},
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Used slave ports",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "ports_used",
+		}, labels): func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				size := s.Used.Ports.size()
+				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(float64(size))
+			}
+		},
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Unreserved slave ports",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "ports_unreserved",
+		}, labels): func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				size := s.Unreserved.Ports.size()
+				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(float64(size))
+			}
+		},
+	}
+
+	if (!ignoreFrameworkTasks) {
+		metrics[prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Framework tasks",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "task_state_time",
+		}, []string{"slave", "task", "executor", "name", "framework", "state"})] = func(st *state, c prometheus.Collector) {
+			for _, f := range st.Frameworks {
+				if !f.Active {
+					continue
+				}
+				for _, task := range f.Completed {
+					values := []string{
+						task.ID,
+						task.SlaveID,
+						task.ExecutorID,
+						task.Name,
+						task.FrameworkID,
+						task.State,
+					}
+					if len(task.Statuses) > 0 {
+						c.(*prometheus.GaugeVec).WithLabelValues(values...).Set(task.Statuses[0].Timestamp)
+					}
+				}
+			}
+		}
+	}
+
 	return &masterCollector{
 		httpClient: httpClient,
-		metrics: map[prometheus.Collector]func(*state, prometheus.Collector){
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Total slave CPUs (fractional)",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "cpus",
-			}, labels): func(st *state, c prometheus.Collector) {
-				for _, s := range st.Slaves {
-					c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Total.CPUs)
-				}
-			},
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Used slave CPUs (fractional)",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "cpus_used",
-			}, labels): func(st *state, c prometheus.Collector) {
-				for _, s := range st.Slaves {
-					c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Used.CPUs)
-				}
-			},
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Unreserved slave CPUs (fractional)",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "cpus_unreserved",
-			}, labels): func(st *state, c prometheus.Collector) {
-				for _, s := range st.Slaves {
-					c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Unreserved.CPUs)
-				}
-			},
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Total slave memory in bytes",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "mem_bytes",
-			}, labels): func(st *state, c prometheus.Collector) {
-				for _, s := range st.Slaves {
-					c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Total.Mem * 1024)
-				}
-			},
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Used slave memory in bytes",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "mem_used_bytes",
-			}, labels): func(st *state, c prometheus.Collector) {
-				for _, s := range st.Slaves {
-					c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Used.Mem * 1024)
-				}
-			},
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Unreserved slave memory in bytes",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "mem_unreserved_bytes",
-			}, labels): func(st *state, c prometheus.Collector) {
-				for _, s := range st.Slaves {
-					c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Unreserved.Mem * 1024)
-				}
-			},
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Total slave disk space in bytes",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "disk_bytes",
-			}, labels): func(st *state, c prometheus.Collector) {
-				for _, s := range st.Slaves {
-					c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Total.Disk * 1024)
-				}
-			},
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Used slave disk space in bytes",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "disk_used_bytes",
-			}, labels): func(st *state, c prometheus.Collector) {
-				for _, s := range st.Slaves {
-					c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Used.Disk * 1024)
-				}
-			},
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Unreserved slave disk in bytes",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "disk_unreserved_bytes",
-			}, labels): func(st *state, c prometheus.Collector) {
-				for _, s := range st.Slaves {
-					c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(s.Unreserved.Disk * 1024)
-				}
-			},
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Total slave ports",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "ports",
-			}, labels): func(st *state, c prometheus.Collector) {
-				for _, s := range st.Slaves {
-					size := s.Total.Ports.size()
-					c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(float64(size))
-				}
-			},
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Used slave ports",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "ports_used",
-			}, labels): func(st *state, c prometheus.Collector) {
-				for _, s := range st.Slaves {
-					size := s.Used.Ports.size()
-					c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(float64(size))
-				}
-			},
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Unreserved slave ports",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "ports_unreserved",
-			}, labels): func(st *state, c prometheus.Collector) {
-				for _, s := range st.Slaves {
-					size := s.Unreserved.Ports.size()
-					c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(float64(size))
-				}
-			},
-			prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Help:      "Framework tasks",
-				Namespace: "mesos",
-				Subsystem: "slave",
-				Name:      "task_state_time",
-			}, []string{"slave", "task", "executor", "name", "framework", "state"}): func(st *state, c prometheus.Collector) {
-				for _, f := range st.Frameworks {
-					if !f.Active {
-						continue
-					}
-					for _, task := range f.Completed {
-						values := []string{
-							task.ID,
-							task.SlaveID,
-							task.ExecutorID,
-							task.Name,
-							task.FrameworkID,
-							task.State,
-						}
-						if len(task.Statuses) > 0 {
-							c.(*prometheus.GaugeVec).WithLabelValues(values...).Set(task.Statuses[0].Timestamp)
-						}
-					}
-				}
-			},
-		},
+		metrics: metrics,
 	}
 }
 

--- a/master_state.go
+++ b/master_state.go
@@ -192,7 +192,7 @@ func newMasterStateCollector(httpClient *httpClient, ignoreFrameworkTasks bool) 
 
 	if (!ignoreFrameworkTasks) {
 		metrics[prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Help:      "Framework tasks",
+			Help:      "Completed framework tasks",
 			Namespace: "mesos",
 			Subsystem: "slave",
 			Name:      "task_state_time",


### PR DESCRIPTION
Add command-line option to ignore `mesos_slave_task_state_time` events, whose frequency is too much for some prometheus instances.

Fixes #5
