### PR TITLE
Fix #12: Scrape Mesos task labels

### DIFF
--- a/common.go
+++ b/common.go
@@ -11,6 +11,37 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+type (
+	resources struct {
+		CPUs  float64 `json:"cpus"`
+		Disk  float64 `json:"disk"`
+		Mem   float64 `json:"mem"`
+		Ports ranges  `json:"ports"`
+	}
+
+	task struct {
+		Name        string    `json:"name"`
+		ID          string    `json:"id"`
+		ExecutorID  string    `json:"executor_id"`
+		FrameworkID string    `json:"framework_id"`
+		SlaveID     string    `json:"slave_id"`
+		State       string    `json:"state"`
+		Labels      []label   `json:"labels"`
+		Resources   resources `json:"resources"`
+		Statuses    []status  `json:"statuses"`
+	}
+
+	label struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}
+
+	status struct {
+		State     string  `json:"state"`
+		Timestamp float64 `json:"timestamp"`
+	}
+)
+
 type metricMap map[string]float64
 
 var (

--- a/master_state.go
+++ b/master_state.go
@@ -14,35 +14,6 @@ import (
 )
 
 type (
-	resources struct {
-		CPUs  float64 `json:"cpus"`
-		Disk  float64 `json:"disk"`
-		Mem   float64 `json:"mem"`
-		Ports ranges  `json:"ports"`
-	}
-
-	task struct {
-		Name        string    `json:"name"`
-		ID          string    `json:"id"`
-		ExecutorID  string    `json:"executor_id"`
-		FrameworkID string    `json:"framework_id"`
-		SlaveID     string    `json:"slave_id"`
-		State       string    `json:"state"`
-		Labels      []label   `json:"labels"`
-		Resources   resources `json:"resources"`
-		Statuses    []status  `json:"statuses"`
-	}
-
-	label struct {
-		Key   string `json:"key"`
-		Value string `json:"value"`
-	}
-
-	status struct {
-		State     string  `json:"state"`
-		Timestamp float64 `json:"timestamp"`
-	}
-
 	slave struct {
 		PID        string    `json:"pid"`
 		Used       resources `json:"used_resources"`

--- a/slave_monitor.go
+++ b/slave_monitor.go
@@ -17,6 +17,7 @@ type (
 		FrameworkID string      `json:"framework_id"`
 		Source      string      `json:"source"`
 		Statistics  *statistics `json:"statistics"`
+		Tasks       []task      `json:"tasks"`
 	}
 
 	statistics struct {

--- a/slave_state.go
+++ b/slave_state.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"regexp"
-	"log"
 
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/slave_state.go
+++ b/slave_state.go
@@ -1,0 +1,128 @@
+// Scrape the /slave(1)/state endpoint to get information on the tasks running
+// on executors. Information scraped at this point:
+//
+// * Labels of running tasks ("mesos_slave_task_labels" series)
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+	"regexp"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type (
+	slaveFramework struct {
+		Executors []executor `json:"executors"`
+	}
+
+	slaveState struct {
+		Frameworks []slaveFramework `json:"frameworks"`
+	}
+
+	slaveStateCollector struct {
+		*http.Client
+		url     string
+		metrics map[prometheus.Collector]func(*slaveState, prometheus.Collector)
+	}
+)
+
+// Task labels must be alphanumeric, no leading digits.
+var invalidLabelNameCharRE = regexp.MustCompile("[^a-zA-Z_0-9]")
+// Replace invalid task label digits by underscores
+func normaliseLabel(label string) string {
+	if len(label) > 0 && '0' <= label[0] && label[0] <= '9' {
+		return "_" + invalidLabelNameCharRE.ReplaceAllString(label[1:], "_");
+	}
+	return invalidLabelNameCharRE.ReplaceAllString(label, "_");
+}
+
+// Return true if `needle` is in `haystack`
+func inArray(needle string, haystack []string) bool {
+	for _, elem := range haystack {
+		if needle == elem {
+			return true
+		}
+	}
+	return false
+}
+
+func newSlaveStateCollector(url string, timeout time.Duration, userTaskLabelList []string) *slaveStateCollector {
+	defaultLabels := []string{"source", "framework_id", "executor_id"}
+
+	// Sanitise user-supplied list of task labels that should be included in the series
+	normalisedUserTaskLabelList := []string{}
+	for _, label := range userTaskLabelList {
+		normalisedUserTaskLabelList = append(normalisedUserTaskLabelList, normaliseLabel(label))
+	}
+
+	taskLabelList := append(defaultLabels, normalisedUserTaskLabelList...)
+
+	metrics := map[prometheus.Collector]func(*slaveState, prometheus.Collector){
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Task labels",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "task_labels",
+		}, taskLabelList): func(st *slaveState, c prometheus.Collector) {
+			for _, f := range st.Frameworks {
+				for _, e := range f.Executors {
+					for _, t := range e.Tasks {
+						// Default labels
+						taskLabels := map[string]string{
+							"source": e.Source,
+							"framework_id": t.FrameworkID,
+							"executor_id": t.ID,
+						}
+						// User labels
+						for _, label := range t.Labels {
+							normalisedLabel := normaliseLabel(label.Key)
+							// Ignore labels not explicitly whitelisted by user
+							if (inArray(normalisedLabel, normalisedUserTaskLabelList)) {
+								taskLabels[normalisedLabel] = label.Value
+							}
+						}
+						c.(*prometheus.GaugeVec).With(taskLabels).Set(1)
+					}
+				}
+			}
+		},
+	}
+
+	return &slaveStateCollector{
+		Client:  &http.Client{Timeout: timeout},
+		url:     url,
+		metrics: metrics,
+	}
+}
+
+func (c *slaveStateCollector) Collect(ch chan<- prometheus.Metric) {
+	u := strings.TrimSuffix(c.url, "/") + "/slave(1)/state"
+	res, err := c.Get(u)
+	if err != nil {
+		log.Printf("Error fetching %s: %s", u, err)
+		return
+	}
+	defer res.Body.Close()
+
+	var s slaveState
+	if err := json.NewDecoder(res.Body).Decode(&s); err != nil {
+		log.Print("Error decoding response body from %s: %s", err)
+		return
+	}
+
+	for c, set := range c.metrics {
+		set(&s, c)
+		c.Collect(ch)
+	}
+}
+
+func (c *slaveStateCollector) Describe(ch chan<- *prometheus.Desc) {
+	for metric := range c.metrics {
+		metric.Describe(ch)
+	}
+}

--- a/slave_state.go
+++ b/slave_state.go
@@ -75,6 +75,9 @@ func newSlaveStateCollector(httpClient *httpClient, userTaskLabelList []string) 
 							"executor_id": e.ID,
 						}
 						// User labels
+						for _, label := range normalisedUserTaskLabelList {
+							taskLabels[label] = ""
+						}
 						for _, label := range t.Labels {
 							normalisedLabel := normaliseLabel(label.Key)
 							// Ignore labels not explicitly whitelisted by user

--- a/slave_state.go
+++ b/slave_state.go
@@ -17,6 +17,7 @@ import (
 
 type (
 	slaveFramework struct {
+		ID        string     `json:"ID"`
 		Executors []executor `json:"executors"`
 	}
 
@@ -75,8 +76,8 @@ func newSlaveStateCollector(url string, timeout time.Duration, userTaskLabelList
 						// Default labels
 						taskLabels := map[string]string{
 							"source": e.Source,
-							"framework_id": t.FrameworkID,
-							"executor_id": t.ID,
+							"framework_id": f.ID,
+							"executor_id": e.ID,
 						}
 						// User labels
 						for _, label := range t.Labels {


### PR DESCRIPTION
This adds a new series, `mesos_slave_task_labels`, that has a value of constant `1` and includes user-specified labels. Example:

```
$ ./mesos_exporter ... -exportedTaskLabels="my.first.label,my.second.label"
```

will export a series like:

```
mesos_slave_task_labels{my_first_label="custom value1",my_second_label="custom value 2",
cluster="...",executor_id="...",framework_id="...",instance="...",job="mesos-slave",source="..."}
```

Note two limitations by Prometheus here:
- Labels to be included must be specified upfront
- Labels are normalised to `[a-zA-Z0-9_]+`
### Adding task labels to other series

While the `task_labels` series isn't of much use on its own, it may be used to add task labels to other time series. For example, if we want to annotate `mem_limit_bytes` with our custom labels, we can use a query like this:

```
mem_limit_bytes * on (source) group_left(my_first_label) mesos_slave_task_labels
```

(The idea for these kind of "joins" stems from here: http://www.robustperception.io/exposing-the-software-version-to-prometheus/)
