### PR TITLE
Support basic auth protected endpoints

### DIFF
--- a/common.go
+++ b/common.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -35,37 +34,42 @@ func counter(subsystem, name, help string, labels ...string) *prometheus.Counter
 	}, labels)
 }
 
+type httpClient struct {
+	http.Client
+	url string
+}
+
 type metricCollector struct {
-	*http.Client
-	url     string
+	*httpClient
 	metrics map[prometheus.Collector]func(metricMap, prometheus.Collector) error
 }
 
-func newMetricCollector(url string, timeout time.Duration, metrics map[prometheus.Collector]func(metricMap, prometheus.Collector) error) *metricCollector {
-	return &metricCollector{
-		url:     url,
-		Client:  &http.Client{Timeout: timeout},
-		metrics: metrics,
-	}
+func newMetricCollector(httpClient *httpClient, metrics map[prometheus.Collector]func(metricMap, prometheus.Collector) error) prometheus.Collector {
+	return &metricCollector{httpClient, metrics}
 }
 
-func (c *metricCollector) Collect(ch chan<- prometheus.Metric) {
-	u := strings.TrimSuffix(c.url, "/") + "/metrics/snapshot"
-	res, err := c.Get(u)
+func (httpClient *httpClient) fetchAndDecode(endpoint string, target interface{}) bool {
+	url := strings.TrimSuffix(httpClient.url, "/") + endpoint
+	res, err := httpClient.Get(url)
 	if err != nil {
-		log.Printf("Error fetching %s: %s", u, err)
+		log.Printf("Error fetching %s: %s", url, err)
 		errorCounter.Inc()
-		return
+		return false
 	}
 	defer res.Body.Close()
 
-	var m metricMap
-	if err := json.NewDecoder(res.Body).Decode(&m); err != nil {
+	if err := json.NewDecoder(res.Body).Decode(&target); err != nil {
 		log.Print("Error decoding response body from %s: %s", err)
 		errorCounter.Inc()
-		return
+		return false
 	}
 
+	return true
+}
+
+func (c *metricCollector) Collect(ch chan<- prometheus.Metric) {
+	var m metricMap
+	c.fetchAndDecode("/metrics/snapshot", &m)
 	for cm, f := range c.metrics {
 		if err := f(m, cm); err != nil {
 			if err == notFoundInMap {

--- a/master.go
+++ b/master.go
@@ -2,12 +2,11 @@ package main
 
 import (
 	"strings"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func newMasterCollector(url string, timeout time.Duration) *metricCollector {
+func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 	metrics := map[prometheus.Collector]func(metricMap, prometheus.Collector) error{
 		// CPU/Disk/Mem resources in free/used
 		gauge("master", "cpus", "Current CPU resources in cluster.", "type"): func(m metricMap, c prometheus.Collector) error {
@@ -277,5 +276,5 @@ func newMasterCollector(url string, timeout time.Duration) *metricCollector {
 			return nil
 		},
 	}
-	return newMetricCollector(url, timeout, metrics)
+	return newMetricCollector(httpClient, metrics)
 }

--- a/slave.go
+++ b/slave.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func newSlaveCollector(url string, timeout time.Duration) *metricCollector {
+func newSlaveCollector(httpClient *httpClient) prometheus.Collector {
 	metrics := map[prometheus.Collector]func(metricMap, prometheus.Collector) error{
 		// CPU/Disk/Mem resources in free/used
 		gauge("slave", "cpus", "Current CPU resources in cluster.", "type"): func(m metricMap, c prometheus.Collector) error {
@@ -189,5 +187,5 @@ func newSlaveCollector(url string, timeout time.Duration) *metricCollector {
 			return nil
 		},
 	}
-	return newMetricCollector(url, timeout, metrics)
+	return newMetricCollector(httpClient, metrics)
 }

--- a/slave_monitor.go
+++ b/slave_monitor.go
@@ -1,12 +1,6 @@
 package main
 
 import (
-	"encoding/json"
-	"log"
-	"net/http"
-	"strings"
-	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -39,8 +33,7 @@ type (
 	}
 
 	slaveCollector struct {
-		*http.Client
-		url     string
+		*httpClient
 		metrics map[*prometheus.Desc]metric
 	}
 
@@ -50,12 +43,11 @@ type (
 	}
 )
 
-func newSlaveMonitorCollector(url string, timeout time.Duration) *slaveCollector {
+func newSlaveMonitorCollector(httpClient *httpClient) prometheus.Collector {
 	labels := []string{"id", "framework_id", "source"}
 
 	return &slaveCollector{
-		Client: &http.Client{Timeout: timeout},
-		url:    url,
+		httpClient: httpClient,
 		metrics: map[*prometheus.Desc]metric{
 			// CPU
 			prometheus.NewDesc(
@@ -139,19 +131,8 @@ func newSlaveMonitorCollector(url string, timeout time.Duration) *slaveCollector
 }
 
 func (c *slaveCollector) Collect(ch chan<- prometheus.Metric) {
-	u := strings.TrimSuffix(c.url, "/") + "/monitor/statistics"
-	res, err := c.Get(u)
-	if err != nil {
-		log.Printf("Error fetching %s: %s", u, err)
-		return
-	}
-	defer res.Body.Close()
-
 	stats := []executor{}
-	if err := json.NewDecoder(res.Body).Decode(&stats); err != nil {
-		log.Print("Error decoding response body from %s: %s", err)
-		return
-	}
+	c.fetchAndDecode("/monitor/statistics", &stats)
 
 	for _, exec := range stats {
 		for desc, m := range c.metrics {


### PR DESCRIPTION
Fixes #18 

At this point it is necessary to pass the authentication credentials using the `MESOS_EXPORTER_{USERNAME,PASSWORD}` environment variables. An additional nice feature could be to support passing authentication information sent to Mesos Exporter through to the Mesos endpoints so that Mesos Exporter doesn't have to be given any credentials at all. This however requires changes in the Go Prometheus client (IIUC).

Note to reviewers: I recommend reviewing the commits independently as they build on each other logically