### PR TITLE
Add -trustedCerts option to allow for custom root CAs

### DIFF
--- a/common.go
+++ b/common.go
@@ -104,7 +104,7 @@ func (httpClient *httpClient) fetchAndDecode(endpoint string, target interface{}
 	defer res.Body.Close()
 
 	if err := json.NewDecoder(res.Body).Decode(&target); err != nil {
-		log.Print("Error decoding response body from %s: %s", err)
+		log.Printf("Error decoding response body from %s: %s", url, err)
 		errorCounter.Inc()
 		return false
 	}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,10 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"crypto/tls"
+	"crypto/x509"
 	"os"
+	"io/ioutil"
 	"time"
 	"strings"
 
@@ -22,9 +25,27 @@ func init() {
 	prometheus.MustRegister(errorCounter)
 }
 
-func mkHttpClient(url string, timeout time.Duration, auth authInfo) *httpClient {
+func getX509CertPool(pemFiles []string) *x509.CertPool {
+	pool := x509.NewCertPool()
+	for _, f := range pemFiles {
+		content, err := ioutil.ReadFile(f)
+		if err != nil {
+			log.Fatal(err)
+		}
+		ok := pool.AppendCertsFromPEM(content)
+		if !ok {
+			log.Fatal("Error parsing .pem file %s", f)
+		}
+	}
+	return pool
+}
+
+func mkHttpClient(url string, timeout time.Duration, auth authInfo, certPool *x509.CertPool) *httpClient {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: certPool},
+	}
 	return &httpClient{
-		http.Client{Timeout: timeout},
+		http.Client{Timeout: timeout, Transport: transport},
 		url,
 		auth,
 	}
@@ -38,6 +59,7 @@ func main() {
 	timeout := fs.Duration("timeout", 5*time.Second, "Master polling timeout")
 	exportedTaskLabels := fs.String("exportedTaskLabels", "", "Comma-separated list of task labels to include in the task_labels metric")
 	ignoreCompletedFrameworkTasks := fs.Bool("ignoreCompletedFrameworkTasks", false, "Don't export task_state_time metric");
+	trustedCerts := fs.String("trustedCerts", "", "Comma-separated list of certificates (.pem files) trusted for requests to Mesos endpoints")
 
 	fs.Parse(os.Args[1:])
 	if *masterURL != "" && *slaveURL != "" {
@@ -49,6 +71,11 @@ func main() {
 		os.Getenv("MESOS_EXPORTER_PASSWORD"),
 	}
 
+	var certPool *x509.CertPool = nil
+	if *trustedCerts != "" {
+		certPool = getX509CertPool(strings.Split(*trustedCerts, ","))
+	}
+
 	switch {
 	case *masterURL != "":
 		for _, f := range []func(*httpClient) prometheus.Collector{
@@ -57,7 +84,7 @@ func main() {
 				return newMasterStateCollector(c, *ignoreCompletedFrameworkTasks)
 			},
 		} {
-			c := f(mkHttpClient(*masterURL, *timeout, auth));
+			c := f(mkHttpClient(*masterURL, *timeout, auth, certPool));
 			if err := prometheus.Register(c); err != nil {
 				log.Fatal(err)
 			}
@@ -81,7 +108,7 @@ func main() {
 		}
 
 		for _, f := range slaveCollectors {
-			c := f(mkHttpClient(*slaveURL, *timeout, auth));
+			c := f(mkHttpClient(*slaveURL, *timeout, auth, certPool));
 			if err := prometheus.Register(c); err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
When sending requests to Mesos endpoints, allow for custom TLS certificates.

Syntax:

```
./mesos_exporter ... -trustedCerts /path/to/cert1.pem,/path/to/cert2.pem ...
```