### PR TITLE
master/cpus_total->system/cpus_total

### DIFF
--- a/master.go
+++ b/master.go
@@ -10,7 +10,7 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 	metrics := map[prometheus.Collector]func(metricMap, prometheus.Collector) error{
 		// CPU/Disk/Mem resources in free/used
 		gauge("master", "cpus", "Current CPU resources in cluster.", "type"): func(m metricMap, c prometheus.Collector) error {
-			total, ok := m["master/cpus_total"]
+			total, ok := m["system/cpus_total"]
 			used, ok := m["master/cpus_used"]
 			if !ok {
 				return notFoundInMap


### PR DESCRIPTION
According to actual test，I found  master/cpus_total value not the cpu total number of machine.
In my opinion，just know the cpu total number of machine and used cpus  of mesos-master.