### PR TITLE
Authenticate redirects with basic HTTP auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,26 @@ metrics from an agent.
 ```sh
 Usage of mesos-exporter:
   -addr string
-       	Address to listen on (default ":9110")
+        Address to listen on (default ":9110")
+  -exportedTaskLabels string
+        Comma-separated list of task labels to include in the task_labels metric
   -ignoreCompletedFrameworkTasks
-       	Don't export task_state_time metric
+        Don't export task_state_time metric
   -master string
-       	Expose metrics from master running on this URL
+        Expose metrics from master running on this URL
   -slave string
-       	Expose metrics from slave running on this URL
+        Expose metrics from slave running on this URL
   -timeout duration
-       	Master polling timeout (default 5s)
+        Master polling timeout (default 5s)
+  -trustedCerts string
+        Comma-separated list of certificates (.pem files) trusted for requests to
+        Mesos endpoints
 ```
+When using HTTP authentication, the following values are read from the environment:
+- `MESOS_EXPORTER_USERNAME`
+- `MESOS_EXPORTER_PASSWORD`
+
+---
 
 Usually you would run one exporter with `-master` pointing to the current
 leader and one exporter for each slave with `-slave` pointing to it. In

--- a/main.go
+++ b/main.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-	"flag"
-	"log"
-	"net/http"
 	"crypto/tls"
 	"crypto/x509"
-	"os"
+	"flag"
 	"io/ioutil"
-	"time"
+	"log"
+	"net/http"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -50,8 +50,8 @@ func mkHttpClient(url string, timeout time.Duration, auth authInfo, certPool *x5
 	var redirectFunc func(req *http.Request, via []*http.Request) error
 	if auth.username != "" && auth.password != "" {
 		// Auth information is only available in the current context -> use lambda function
-		redirectFunc = func(req *http.Request, via []*http.Request) error{
-				req.SetBasicAuth(auth.username, auth.password)
+		redirectFunc = func(req *http.Request, via []*http.Request) error {
+			req.SetBasicAuth(auth.username, auth.password)
 			return nil
 		}
 	}
@@ -70,7 +70,7 @@ func main() {
 	slaveURL := fs.String("slave", "", "Expose metrics from slave running on this URL")
 	timeout := fs.Duration("timeout", 5*time.Second, "Master polling timeout")
 	exportedTaskLabels := fs.String("exportedTaskLabels", "", "Comma-separated list of task labels to include in the task_labels metric")
-	ignoreCompletedFrameworkTasks := fs.Bool("ignoreCompletedFrameworkTasks", false, "Don't export task_state_time metric");
+	ignoreCompletedFrameworkTasks := fs.Bool("ignoreCompletedFrameworkTasks", false, "Don't export task_state_time metric")
 	trustedCerts := fs.String("trustedCerts", "", "Comma-separated list of certificates (.pem files) trusted for requests to Mesos endpoints")
 
 	fs.Parse(os.Args[1:])
@@ -96,7 +96,7 @@ func main() {
 				return newMasterStateCollector(c, *ignoreCompletedFrameworkTasks)
 			},
 		} {
-			c := f(mkHttpClient(*masterURL, *timeout, auth, certPool));
+			c := f(mkHttpClient(*masterURL, *timeout, auth, certPool))
 			if err := prometheus.Register(c); err != nil {
 				log.Fatal(err)
 			}
@@ -113,14 +113,14 @@ func main() {
 			},
 		}
 		if *exportedTaskLabels != "" {
-			slaveLabels := strings.Split(*exportedTaskLabels, ",");
-			slaveCollectors = append(slaveCollectors, func (c *httpClient) prometheus.Collector{
+			slaveLabels := strings.Split(*exportedTaskLabels, ",")
+			slaveCollectors = append(slaveCollectors, func(c *httpClient) prometheus.Collector {
 				return newSlaveStateCollector(c, slaveLabels)
 			})
 		}
 
 		for _, f := range slaveCollectors {
-			c := f(mkHttpClient(*slaveURL, *timeout, auth, certPool));
+			c := f(mkHttpClient(*slaveURL, *timeout, auth, certPool))
 			if err := prometheus.Register(c); err != nil {
 				log.Fatal(err)
 			}

--- a/master_state.go
+++ b/master_state.go
@@ -161,7 +161,7 @@ func newMasterStateCollector(httpClient *httpClient, ignoreFrameworkTasks bool) 
 		},
 	}
 
-	if (!ignoreFrameworkTasks) {
+	if !ignoreFrameworkTasks {
 		metrics[prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Help:      "Completed framework tasks",
 			Namespace: "mesos",
@@ -191,7 +191,7 @@ func newMasterStateCollector(httpClient *httpClient, ignoreFrameworkTasks bool) 
 
 	return &masterCollector{
 		httpClient: httpClient,
-		metrics: metrics,
+		metrics:    metrics,
 	}
 }
 

--- a/slave_state.go
+++ b/slave_state.go
@@ -28,12 +28,13 @@ type (
 
 // Task labels must be alphanumeric, no leading digits.
 var invalidLabelNameCharRE = regexp.MustCompile("[^a-zA-Z_0-9]")
+
 // Replace invalid task label digits by underscores
 func normaliseLabel(label string) string {
 	if len(label) > 0 && '0' <= label[0] && label[0] <= '9' {
-		return "_" + invalidLabelNameCharRE.ReplaceAllString(label[1:], "_");
+		return "_" + invalidLabelNameCharRE.ReplaceAllString(label[1:], "_")
 	}
-	return invalidLabelNameCharRE.ReplaceAllString(label, "_");
+	return invalidLabelNameCharRE.ReplaceAllString(label, "_")
 }
 
 // Return true if `needle` is in `haystack`
@@ -69,9 +70,9 @@ func newSlaveStateCollector(httpClient *httpClient, userTaskLabelList []string) 
 					for _, t := range e.Tasks {
 						// Default labels
 						taskLabels := map[string]string{
-							"source": e.Source,
+							"source":       e.Source,
 							"framework_id": f.ID,
-							"executor_id": e.ID,
+							"executor_id":  e.ID,
 						}
 						// User labels
 						for _, label := range normalisedUserTaskLabelList {
@@ -80,7 +81,7 @@ func newSlaveStateCollector(httpClient *httpClient, userTaskLabelList []string) 
 						for _, label := range t.Labels {
 							normalisedLabel := normaliseLabel(label.Key)
 							// Ignore labels not explicitly whitelisted by user
-							if (inArray(normalisedLabel, normalisedUserTaskLabelList)) {
+							if inArray(normalisedLabel, normalisedUserTaskLabelList) {
 								taskLabels[normalisedLabel] = label.Value
 							}
 						}


### PR DESCRIPTION
Go only automatically authenticates redirected HTTP requests under certain circumstances, i.e. Go version 1.8+ and when redirecting to an _identical_ domain or _any_ subdomain ([source](https://golang.org/pkg/net/http/#Client)).
Mesos nodes usually use hostnames, therefore redirects to the leading master will not work with HTTP authentication and a default Go setup.

- Implement redirect functionality
- Minor documentation update