### PR TITLE
Export attributes of mesos agents as `mesos_slave_attributes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ metrics from an agent.
 Usage of mesos-exporter:
   -addr string
         Address to listen on (default ":9110")
+  -exportedSlaveAttributes string
+        Comma-separated list of slave attributes to include in the corresponding metric
   -exportedTaskLabels string
-        Comma-separated list of task labels to include in the task_labels metric
+        Comma-separated list of task labels to include in the corresponding metric
   -ignoreCompletedFrameworkTasks
         Don't export task_state_time metric
   -master string

--- a/common.go
+++ b/common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -192,7 +193,31 @@ func (c *metricCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (c *metricCollector) Describe(ch chan<- *prometheus.Desc) {
-	for m, _ := range c.metrics {
+	for m := range c.metrics {
 		m.Describe(ch)
 	}
+}
+
+var invalidLabelNameCharRE = regexp.MustCompile("(^[^a-zA-Z_])|([^a-zA-Z0-9_])")
+
+// Sanitize label names according to https://prometheus.io/docs/concepts/data_model/
+func normaliseLabel(label string) string {
+	return invalidLabelNameCharRE.ReplaceAllString(label, "_")
+}
+
+func normaliseLabelList(labelList []string) []string {
+	normalisedLabelList := []string{}
+	for _, label := range labelList {
+		normalisedLabelList = append(normalisedLabelList, normaliseLabel(label))
+	}
+	return normalisedLabelList
+}
+
+func stringinSlice(string string, slice []string) bool {
+	for _, elem := range slice {
+		if string == elem {
+			return true
+		}
+	}
+	return false
 }

--- a/common.go
+++ b/common.go
@@ -213,7 +213,7 @@ func normaliseLabelList(labelList []string) []string {
 	return normalisedLabelList
 }
 
-func stringinSlice(string string, slice []string) bool {
+func stringInSlice(string string, slice []string) bool {
 	for _, elem := range slice {
 		if string == elem {
 			return true

--- a/master_state.go
+++ b/master_state.go
@@ -10,10 +10,11 @@ import (
 
 type (
 	slave struct {
-		PID        string    `json:"pid"`
-		Used       resources `json:"used_resources"`
-		Unreserved resources `json:"unreserved_resources"`
-		Total      resources `json:"resources"`
+		PID        string            `json:"pid"`
+		Used       resources         `json:"used_resources"`
+		Unreserved resources         `json:"unreserved_resources"`
+		Total      resources         `json:"resources"`
+		Attributes map[string]string `json:"attributes"`
 	}
 
 	framework struct {
@@ -33,7 +34,7 @@ type (
 	}
 )
 
-func newMasterStateCollector(httpClient *httpClient, ignoreFrameworkTasks bool) prometheus.Collector {
+func newMasterStateCollector(httpClient *httpClient, ignoreFrameworkTasks bool, slaveAttributeLabels []string) prometheus.Collector {
 	labels := []string{"slave"}
 	metrics := map[prometheus.Collector]func(*state, prometheus.Collector){
 		prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -159,6 +160,36 @@ func newMasterStateCollector(httpClient *httpClient, ignoreFrameworkTasks bool) 
 				c.(*prometheus.GaugeVec).WithLabelValues(s.PID).Set(float64(size))
 			}
 		},
+	}
+
+	if len(slaveAttributeLabels) > 0 {
+		normalisedAttributeLabels := normaliseLabelList(slaveAttributeLabels)
+		slaveAttributesLabelsExport := append(labels, normalisedAttributeLabels...)
+
+		metrics[prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Slave attributes",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "attributes",
+		}, slaveAttributesLabelsExport)] = func(st *state, c prometheus.Collector) {
+			for _, s := range st.Slaves {
+				slaveAttributesExport := map[string]string{
+					"slave": s.PID,
+				}
+
+				// (Empty) user labels
+				for _, label := range normalisedAttributeLabels {
+					slaveAttributesExport[label] = ""
+				}
+				for key, value := range s.Attributes {
+					normalisedLabel := normaliseLabel(key)
+					if stringinSlice(normalisedLabel, normalisedAttributeLabels) {
+						slaveAttributesExport[normalisedLabel] = value
+					}
+				}
+				c.(*prometheus.GaugeVec).With(slaveAttributesExport).Set(1)
+			}
+		}
 	}
 
 	if !ignoreFrameworkTasks {

--- a/master_state.go
+++ b/master_state.go
@@ -183,7 +183,7 @@ func newMasterStateCollector(httpClient *httpClient, ignoreFrameworkTasks bool, 
 				}
 				for key, value := range s.Attributes {
 					normalisedLabel := normaliseLabel(key)
-					if stringinSlice(normalisedLabel, normalisedAttributeLabels) {
+					if stringInSlice(normalisedLabel, normalisedAttributeLabels) {
 						slaveAttributesExport[normalisedLabel] = value
 					}
 				}

--- a/slave_state.go
+++ b/slave_state.go
@@ -2,6 +2,7 @@
 // on executors. Information scraped at this point:
 //
 // * Labels of running tasks ("mesos_slave_task_labels" series)
+// * Attributes of mesos slaves ("mesos_slave_attributes")
 package main
 
 import (
@@ -14,8 +15,11 @@ type (
 		Executors []executor `json:"executors"`
 	}
 
+	// similar to /master/state's 'slave', but with small differences
 	slaveState struct {
-		Frameworks []slaveFramework `json:"frameworks"`
+		PID        string            `json:"pid"`
+		Attributes map[string]string `json:"attributes"`
+		Frameworks []slaveFramework  `json:"frameworks"`
 	}
 
 	slaveStateCollector struct {
@@ -24,24 +28,28 @@ type (
 	}
 )
 
-func newSlaveStateCollector(httpClient *httpClient, userTaskLabelList []string) *slaveStateCollector {
-	defaultLabels := []string{"source", "framework_id", "executor_id"}
+func newSlaveStateCollector(httpClient *httpClient, userTaskLabelList []string, slaveAttributeLabelList []string) *slaveStateCollector {
+	var metrics = map[prometheus.Collector]func(*slaveState, prometheus.Collector){}
+	defaultLabels := []string{"slave"}
 
-	normalisedUserTaskLabelList := normaliseLabelList(userTaskLabelList)
-	taskLabelList := append(defaultLabels, normalisedUserTaskLabelList...)
+	if len(userTaskLabelList) > 0 {
+		defaultTaskLabels := []string{"source", "framework_id", "executor_id"}
+		normalisedUserTaskLabelList := normaliseLabelList(userTaskLabelList)
+		taskLabelList := append(defaultLabels, defaultTaskLabels...)
+		taskLabelList = append(taskLabelList, normalisedUserTaskLabelList...)
 
-	metrics := map[prometheus.Collector]func(*slaveState, prometheus.Collector){
-		prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		metrics[prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Help:      "Task labels",
 			Namespace: "mesos",
 			Subsystem: "slave",
 			Name:      "task_labels",
-		}, taskLabelList): func(st *slaveState, c prometheus.Collector) {
+		}, taskLabelList)] = func(st *slaveState, c prometheus.Collector) {
 			for _, f := range st.Frameworks {
 				for _, e := range f.Executors {
 					for _, t := range e.Tasks {
 						// Default labels
 						taskLabels := map[string]string{
+							"slave":        st.PID,
 							"source":       e.Source,
 							"framework_id": f.ID,
 							"executor_id":  e.ID,
@@ -61,7 +69,34 @@ func newSlaveStateCollector(httpClient *httpClient, userTaskLabelList []string) 
 					}
 				}
 			}
-		},
+		}
+	}
+
+	if len(slaveAttributeLabelList) > 0 {
+		normalisedAttributeLabels := normaliseLabelList(slaveAttributeLabelList)
+		AttributeLabelList := append(defaultLabels, normalisedAttributeLabels...)
+		metrics[prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Help:      "Slave attributes",
+			Namespace: "mesos",
+			Subsystem: "slave",
+			Name:      "attributes",
+		}, AttributeLabelList)] = func(st *slaveState, c prometheus.Collector) {
+			slaveAttributesExport := map[string]string{
+				"slave": st.PID,
+			}
+
+			// (Empty) user labels
+			for _, label := range normalisedAttributeLabels {
+				slaveAttributesExport[label] = ""
+			}
+			for key, value := range st.Attributes {
+				normalisedLabel := normaliseLabel(key)
+				if stringinSlice(normalisedLabel, normalisedAttributeLabels) {
+					slaveAttributesExport[normalisedLabel] = value
+				}
+			}
+			c.(*prometheus.GaugeVec).With(slaveAttributesExport).Set(1)
+		}
 	}
 
 	return &slaveStateCollector{httpClient, metrics}


### PR DESCRIPTION
A comma-separated list of attribute keys can be supplied via the configuration variable `exportedSlaveAttributes`.
The key value pairs are exported as labels of the metric `mesos_slave_attributes`.