### PR TITLE
Avoid exporting stale/old/deprecated task_labels/slave_attributes

### DIFF
--- a/common.go
+++ b/common.go
@@ -221,3 +221,11 @@ func stringInSlice(string string, slice []string) bool {
 	}
 	return false
 }
+
+func getLabelValuesFromMap(labels prometheus.Labels, orderedLabelKeys []string) []string {
+	labelValues := []string{}
+	for _, label := range orderedLabelKeys {
+		labelValues = append(labelValues, labels[label])
+	}
+	return labelValues
+}


### PR DESCRIPTION
- Export **new** metric every scrape instead of exporting old metrics which hold state (via const metric)
- Executor structure used in `slave_state` was wrongly declared and didn't export executor_id

Additionally,`task_id` is exported in slave_task_label. This is a (potentially) breaking change, if users implicitly rely on metrics to be unique. This can be handled by writing a corresponding [relabel config rule](https://prometheus.io/docs/operating/configuration/#%3Crelabel_config%3E) (`labeldrop`).