### PR TITLE
Add strict mode authentication #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Usage of mesos_exporter:
         Username to use for HTTP or strict mode authentication
   -password string
         Password to use for HTTP or strict mode authentication
-  -loginUrl
+  -loginURL
         URL for strict mode authentication (default https://leader.mesos/acs/api/v1/auth/login).
   -trustedCerts string
         Comma-separated list of certificates (.pem files) trusted for requests to Mesos endpoints

--- a/README.md
+++ b/README.md
@@ -22,12 +22,23 @@ Usage of mesos_exporter:
         Expose metrics from slave running on this URL
   -timeout duration
         Master polling timeout (default 10s)
+  -username string
+        Username to use for HTTP or strict mode authentication
+  -password string
+        Password to use for HTTP authentication
   -trustedCerts string
         Comma-separated list of certificates (.pem files) trusted for requests to
         Mesos endpoints
+  -strictMode
+        Enable strict mode API authentication
+  -privateKey
+        Private key used for strict mode authentication. This MUST be provided
+        when using strict mode or the program will exit.
+  -skipSSLVerify
+        Disable SSL certificate verification
 ```
-When using HTTP authentication, the following values are read from the environment:
 
+When using HTTP or strict mode authentication, the following values are read from the environment, if they are not specified at run time:
 - `MESOS_EXPORTER_USERNAME`
 - `MESOS_EXPORTER_PASSWORD`
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ Usage of mesos_exporter:
   -username string
         Username to use for HTTP or strict mode authentication
   -password string
-        Password to use for HTTP authentication
+        Password to use for HTTP or strict mode authentication
+  -loginUrl
+        URL for strict mode authentication (default https://leader.mesos/acs/api/v1/auth/login).
   -trustedCerts string
-        Comma-separated list of certificates (.pem files) trusted for requests to
-        Mesos endpoints
+        Comma-separated list of certificates (.pem files) trusted for requests to Mesos endpoints
   -strictMode
         Enable strict mode API authentication
   -privateKey
-        Private key used for strict mode authentication. This MUST be provided
-        when using strict mode or the program will exit.
+        Private key used for strict mode authentication. This must be provided
+        when using strict mode. However, it can be read from the environment if the secret store is used. 
   -skipSSLVerify
         Disable SSL certificate verification
 ```
@@ -41,6 +42,7 @@ Usage of mesos_exporter:
 When using HTTP or strict mode authentication, the following values are read from the environment, if they are not specified at run time:
 - `MESOS_EXPORTER_USERNAME`
 - `MESOS_EXPORTER_PASSWORD`
+- `MESOS_EXPORTER_PRIVATE_KEY`
 
 
 ## Prometheus Configuration

--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@ Usage of mesos_exporter:
   -timeout duration
         Master polling timeout (default 10s)
   -username string
-        Username to use for HTTP or strict mode authentication
+        Username to use for HTTP or in DC/OS strict mode authentication
   -password string
-        Password to use for HTTP or strict mode authentication
-  -loginURL
-        URL for strict mode authentication (default https://leader.mesos/acs/api/v1/auth/login).
+        Password to use for HTTP or in DC/OS strict mode authentication
+  -dcosLoginURL
+        URL for DC/OS strict mode authentication (default https://leader.mesos/acs/api/v1/auth/login).
   -trustedCerts string
         Comma-separated list of certificates (.pem files) trusted for requests to Mesos endpoints
-  -strictMode
-        Enable strict mode API authentication
-  -privateKey
-        Private key used for strict mode authentication. This must be provided
-        when using strict mode. However, it can be read from the environment if the secret store is used. 
-  -skipSSLVerify
-        Disable SSL certificate verification
+  -dcosStrictMode
+        Enable strict mode API authentication when using mesos_exporter with DC/OS
+  -dcosPrivateKey
+        Private key used for DC/OS strict mode authentication. This must be provided when using strict mode. However,
+        it can be read from the environment if the secret store is used. 
+  -dcosSkipSSLVerify
+        Disable SSL certificate verification during DC/OS authentication
 ```
 
 When using HTTP or strict mode authentication, the following values are read from the environment, if they are not specified at run time:

--- a/common.go
+++ b/common.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
+	"github.com/dgrijalva/jwt-go"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -46,22 +50,22 @@ type (
 	}
 
 	tokenRequest struct {
-		UID string `json:"uid"`
+		UID   string `json:"uid"`
 		Token string `json:"token"`
 	}
 
 	mesosSecret struct {
 		LoginEndpoint string `json:"login_endpoint"`
-		PrivateKey string `json:"private_key"`
-		Scheme string `json:"scheme"`
-		UID string `json:"uid"`
+		PrivateKey    string `json:"private_key"`
+		Scheme        string `json:"scheme"`
+		UID           string `json:"uid"`
 	}
 )
 
 type metricMap map[string]float64
 
 var (
-	notFoundInMap = errors.New("Couldn't find key in map")
+	errNotFoundInMap = errors.New("Couldn't find key in map")
 )
 
 type settableCounterVec struct {
@@ -143,12 +147,14 @@ func counter(subsystem, name, help string, labels ...string) *settableCounterVec
 }
 
 type authInfo struct {
-	username string
-	password string
-	loginUrl string
-	token string
-	strictMode bool
-	privateKey string
+	username      string
+	password      string
+	loginURL      string
+	token         string
+	tokenExpire   int64
+	signingKey    []byte
+	strictMode    bool
+	privateKey    string
 	skipSSLVerify bool
 }
 
@@ -167,6 +173,66 @@ func newMetricCollector(httpClient *httpClient, metrics map[prometheus.Collector
 	return &metricCollector{httpClient, metrics}
 }
 
+func signingToken(httpClient *httpClient) string {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM(httpClient.auth.signingKey)
+	if err != nil {
+		log.Printf("Error parsing privateKey: %s", err)
+	}
+
+	expireToken := time.Now().Add(time.Hour * 1).Unix()
+	httpClient.auth.tokenExpire = expireToken
+
+	// Create the token
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"uid": httpClient.auth.username,
+		"exp": expireToken,
+	})
+	// Sign and get the complete encoded token as a string
+	tokenString, err := token.SignedString(signKey)
+	if err != nil {
+		log.Printf("Error creating login token: %s", err)
+		return ""
+	}
+	return tokenString
+}
+
+func authToken(httpClient *httpClient) string {
+	currentTime := time.Now().Unix()
+	if currentTime > httpClient.auth.tokenExpire {
+		url := httpClient.auth.loginURL
+		signingToken := signingToken(httpClient)
+		body, err := json.Marshal(&tokenRequest{UID: httpClient.auth.username, Token: signingToken})
+		if err != nil {
+			log.Printf("Error creating JSON request: %s", err)
+			return ""
+		}
+		buffer := bytes.NewBuffer(body)
+		req, err := http.NewRequest("POST", url, buffer)
+		if err != nil {
+			log.Printf("Error creating HTTP request to %s: %s", url, err)
+			return ""
+		}
+		req.Header.Add("Content-Type", "application/json")
+		res, err := httpClient.Do(req)
+		if err != nil {
+			log.Printf("Error fetching %s: %s", url, err)
+			errorCounter.Inc()
+			return ""
+		}
+		defer res.Body.Close()
+
+		var token tokenResponse
+		if err := json.NewDecoder(res.Body).Decode(&token); err != nil {
+			log.Printf("Error decoding response body from %s: %s", url, err)
+			errorCounter.Inc()
+			return ""
+		}
+
+		httpClient.auth.token = fmt.Sprintf("token=%s", token.Token)
+	}
+	return httpClient.auth.token
+}
+
 func (httpClient *httpClient) fetchAndDecode(endpoint string, target interface{}) bool {
 	url := strings.TrimSuffix(httpClient.url, "/") + endpoint
 	req, err := http.NewRequest("GET", url, nil)
@@ -178,7 +244,7 @@ func (httpClient *httpClient) fetchAndDecode(endpoint string, target interface{}
 		req.SetBasicAuth(httpClient.auth.username, httpClient.auth.password)
 	}
 	if httpClient.auth.strictMode {
-		req.Header.Add("Authorization", httpClient.auth.token)
+		req.Header.Add("Authorization", authToken(httpClient))
 	}
 	res, err := httpClient.Do(req)
 	if err != nil {
@@ -202,7 +268,7 @@ func (c *metricCollector) Collect(ch chan<- prometheus.Metric) {
 	c.fetchAndDecode("/metrics/snapshot", &m)
 	for cm, f := range c.metrics {
 		if err := f(m, cm); err != nil {
-			if err == notFoundInMap {
+			if err == errNotFoundInMap {
 				ch := make(chan *prometheus.Desc, 1)
 				cm.Describe(ch)
 				log.Printf("Couldn't find fields required to update %s\n", <-ch)

--- a/common.go
+++ b/common.go
@@ -49,6 +49,13 @@ type (
 		UID string `json:"uid"`
 		Token string `json:"token"`
 	}
+
+	mesosSecret struct {
+		LoginEndpoint string `json:"login_endpoint"`
+		PrivateKey string `json:"private_key"`
+		Scheme string `json:"scheme"`
+		UID string `json:"uid"`
+	}
 )
 
 type metricMap map[string]float64
@@ -138,6 +145,7 @@ func counter(subsystem, name, help string, labels ...string) *settableCounterVec
 type authInfo struct {
 	username string
 	password string
+	loginUrl string
 	token string
 	strictMode bool
 	privateKey string
@@ -166,7 +174,7 @@ func (httpClient *httpClient) fetchAndDecode(endpoint string, target interface{}
 		log.Printf("Error creating HTTP request to %s: %s", url, err)
 		return false
 	}
-	if httpClient.auth.username != "" && httpClient.auth.password != "" && !httpClient.auth.strictMode {
+	if httpClient.auth.username != "" && httpClient.auth.password != "" {
 		req.SetBasicAuth(httpClient.auth.username, httpClient.auth.password)
 	}
 	if httpClient.auth.strictMode {

--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func main() {
 	strictMode := fs.Bool("strictMode", false, "Use strict mode authentication")
 	username := fs.String("username", "", "Username for authentication")
 	password := fs.String("password", "", "Password for authentication")
-	loginUrl := fs.String("loginUrl", "https://leader.mesos/acs/api/v1/auth/login", "URLfor strict mode authentication")
+	loginUrl := fs.String("loginUrl", "https://leader.mesos/acs/api/v1/auth/login", "URL for strict mode authentication")
 	privateKey := fs.String("privateKey", "", "File path to certificate for strict mode authentication")
 	skipSSLVerify := fs.Bool("skipSSLVerify", false, "Skip SSL certificate verification")
 

--- a/main.go
+++ b/main.go
@@ -75,21 +75,40 @@ func mkHttpClient(url string, timeout time.Duration, auth authInfo, certPool *x5
 	return client
 }
 
-func loginAuthToken(username string, privateKey string) string {
-	absPath, _ := filepath.Abs(privateKey)
-	signBytes, err := ioutil.ReadFile(absPath)
-	if err != nil {
-		log.Printf("Error reading private key %s: %s", absPath, err)
-		return ""
+func parsePrivateKey(httpClient *httpClient) []byte {
+	if _, err := os.Stat(httpClient.auth.privateKey); os.IsNotExist(err) {
+		buffer := bytes.NewBuffer([]byte(httpClient.auth.privateKey))
+		var key mesosSecret
+		if err := json.NewDecoder(buffer).Decode(&key); err != nil {
+			log.Printf("Error decoding prviate key %s: %s", key, err)
+			errorCounter.Inc()
+			return []byte{}
+		}
+		httpClient.auth.username = key.UID
+		httpClient.auth.loginUrl = key.LoginEndpoint
+		return []byte(key.PrivateKey)
+	} else {
+		absPath, _ := filepath.Abs(httpClient.auth.privateKey)
+		key, err := ioutil.ReadFile(absPath)
+		if err != nil {
+			log.Printf("Error reading private key %s: %s", absPath, err)
+			errorCounter.Inc()
+			return []byte{}
+		}
+		return key
 	}
-	signKey, err := jwt.ParseRSAPrivateKeyFromPEM(signBytes)
+}
+
+func loginAuthToken(httpClient *httpClient) string {
+	key := parsePrivateKey(httpClient)
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM(key)
 	if err != nil {
-		log.Printf("Error parsing privateKey %s: %s", absPath, err)
+		log.Printf("Error parsing privateKey: %s", err)
 	}
 
 	// Create the token
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
-		"uid": username,
+		"uid": httpClient.auth.username,
 	})
 	// Sign and get the complete encoded token as a string
 	tokenString, err := token.SignedString(signKey)
@@ -101,8 +120,8 @@ func loginAuthToken(username string, privateKey string) string {
 }
 
 func authToken(httpClient *httpClient) string {
-	url := "https://master.mesos/acs/api/v1/auth/login"
-	loginToken := loginAuthToken(httpClient.auth.username, httpClient.auth.privateKey)
+	url := httpClient.auth.loginUrl
+	loginToken := loginAuthToken(httpClient)
 	body, err := json.Marshal(&tokenRequest{UID: httpClient.auth.username, Token: loginToken})
 	if err != nil {
 		log.Printf("Error creating JSON request: %s", err)
@@ -155,7 +174,8 @@ func main() {
 	strictMode := fs.Bool("strictMode", false, "Use strict mode authentication")
 	username := fs.String("username", "", "Username for authentication")
 	password := fs.String("password", "", "Password for authentication")
-	privateKey := fs.String("privateKey", "", "Certificate for strict mode authentication")
+	loginUrl := fs.String("loginUrl", "https://leader.mesos/acs/api/v1/auth/login", "URLfor strict mode authentication")
+	privateKey := fs.String("privateKey", "", "File path to certificate for strict mode authentication")
 	skipSSLVerify := fs.Bool("skipSSLVerify", false, "Skip SSL certificate verification")
 
 	fs.Parse(os.Args[1:])
@@ -163,15 +183,16 @@ func main() {
 		log.Fatal("Only -master or -slave can be given at a time")
 	}
 
-	if *strictMode && *privateKey == "" {
-		log.Fatal("Must specify a private key when using strict mode authentiation!")
-		os.Exit(1)
-	}
-
 	auth := authInfo{
 		strictMode: *strictMode,
 		skipSSLVerify: *skipSSLVerify,
-		privateKey: *privateKey,
+		loginUrl: *loginUrl,
+	}
+
+	if *strictMode && *privateKey != "" {
+		auth.privateKey = *privateKey
+	} else {
+		auth.privateKey = os.Getenv("MESOS_EXPORTER_PRIVATE_KEY")
 	}
 
 	if *username != "" {

--- a/main.go
+++ b/main.go
@@ -1,21 +1,19 @@
 package main
 
 import (
-	"path/filepath"
-	"fmt"
 	"bytes"
-	"encoding/json"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"flag"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -46,7 +44,7 @@ func getX509CertPool(pemFiles []string) *x509.CertPool {
 	return pool
 }
 
-func mkHttpClient(url string, timeout time.Duration, auth authInfo, certPool *x509.CertPool) *httpClient {
+func mkHTTPClient(url string, timeout time.Duration, auth authInfo, certPool *x509.CertPool) *httpClient {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{RootCAs: certPool, InsecureSkipVerify: auth.skipSSLVerify},
 	}
@@ -69,7 +67,7 @@ func mkHttpClient(url string, timeout time.Duration, auth authInfo, certPool *x5
 	}
 
 	if auth.strictMode {
-		client.auth.token = authToken(client)
+		client.auth.signingKey = parsePrivateKey(client)
 	}
 
 	return client
@@ -85,71 +83,17 @@ func parsePrivateKey(httpClient *httpClient) []byte {
 			return []byte{}
 		}
 		httpClient.auth.username = key.UID
-		httpClient.auth.loginUrl = key.LoginEndpoint
+		httpClient.auth.loginURL = key.LoginEndpoint
 		return []byte(key.PrivateKey)
-	} else {
-		absPath, _ := filepath.Abs(httpClient.auth.privateKey)
-		key, err := ioutil.ReadFile(absPath)
-		if err != nil {
-			log.Printf("Error reading private key %s: %s", absPath, err)
-			errorCounter.Inc()
-			return []byte{}
-		}
-		return key
 	}
-}
-
-func loginAuthToken(httpClient *httpClient) string {
-	key := parsePrivateKey(httpClient)
-	signKey, err := jwt.ParseRSAPrivateKeyFromPEM(key)
+	absPath, _ := filepath.Abs(httpClient.auth.privateKey)
+	key, err := ioutil.ReadFile(absPath)
 	if err != nil {
-		log.Printf("Error parsing privateKey: %s", err)
-	}
-
-	// Create the token
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
-		"uid": httpClient.auth.username,
-	})
-	// Sign and get the complete encoded token as a string
-	tokenString, err := token.SignedString(signKey)
-	if err != nil {
-		log.Printf("Error creating login token %s: %s", token, err)
-		return ""
-	}
-	return tokenString
-}
-
-func authToken(httpClient *httpClient) string {
-	url := httpClient.auth.loginUrl
-	loginToken := loginAuthToken(httpClient)
-	body, err := json.Marshal(&tokenRequest{UID: httpClient.auth.username, Token: loginToken})
-	if err != nil {
-		log.Printf("Error creating JSON request: %s", err)
-		return ""
-	}
-	buffer := bytes.NewBuffer(body)
-	req, err := http.NewRequest("POST", url, buffer)
-	if err != nil {
-		log.Printf("Error creating HTTP request to %s: %s", url, err)
-		return ""
-	}
-	req.Header.Add("Content-Type", "application/json")
-	res, err := httpClient.Do(req)
-	if err != nil {
-		log.Printf("Error fetching %s: %s", url, err)
+		log.Printf("Error reading private key %s: %s", absPath, err)
 		errorCounter.Inc()
-		return ""
+		return []byte{}
 	}
-	defer res.Body.Close()
-
-	var token tokenResponse
-	if err := json.NewDecoder(res.Body).Decode(&token); err != nil {
-		log.Printf("Error decoding response body from %s: %s", url, err)
-		errorCounter.Inc()
-		return ""
-	}
-
-	return fmt.Sprintf("token=%s", token.Token)
+	return key
 }
 
 func csvInputToList(input string) []string {
@@ -174,7 +118,7 @@ func main() {
 	strictMode := fs.Bool("strictMode", false, "Use strict mode authentication")
 	username := fs.String("username", "", "Username for authentication")
 	password := fs.String("password", "", "Password for authentication")
-	loginUrl := fs.String("loginUrl", "https://leader.mesos/acs/api/v1/auth/login", "URL for strict mode authentication")
+	loginURL := fs.String("loginURL", "https://leader.mesos/acs/api/v1/auth/login", "URL for strict mode authentication")
 	privateKey := fs.String("privateKey", "", "File path to certificate for strict mode authentication")
 	skipSSLVerify := fs.Bool("skipSSLVerify", false, "Skip SSL certificate verification")
 
@@ -184,9 +128,9 @@ func main() {
 	}
 
 	auth := authInfo{
-		strictMode: *strictMode,
+		strictMode:    *strictMode,
 		skipSSLVerify: *skipSSLVerify,
-		loginUrl: *loginUrl,
+		loginURL:      *loginURL,
 	}
 
 	if *strictMode && *privateKey != "" {
@@ -207,7 +151,7 @@ func main() {
 		auth.password = os.Getenv("MESOS_EXPORTER_PASSWORD")
 	}
 
-	var certPool *x509.CertPool = nil
+	var certPool *x509.CertPool
 	if *trustedCerts != "" {
 		certPool = getX509CertPool(csvInputToList(*trustedCerts))
 	}
@@ -223,7 +167,7 @@ func main() {
 				return newMasterStateCollector(c, slaveAttributeLabels)
 			},
 		} {
-			c := f(mkHttpClient(*masterURL, *timeout, auth, certPool))
+			c := f(mkHTTPClient(*masterURL, *timeout, auth, certPool))
 			if err := prometheus.Register(c); err != nil {
 				log.Fatal(err)
 			}
@@ -247,7 +191,7 @@ func main() {
 		}
 
 		for _, f := range slaveCollectors {
-			c := f(mkHttpClient(*slaveURL, *timeout, auth, certPool))
+			c := f(mkHTTPClient(*slaveURL, *timeout, auth, certPool))
 			if err := prometheus.Register(c); err != nil {
 				log.Fatal(err)
 			}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"path/filepath"
+	"fmt"
+	"bytes"
+	"encoding/json"
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
@@ -11,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dgrijalva/jwt-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -43,7 +48,7 @@ func getX509CertPool(pemFiles []string) *x509.CertPool {
 
 func mkHttpClient(url string, timeout time.Duration, auth authInfo, certPool *x509.CertPool) *httpClient {
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{RootCAs: certPool},
+		TLSClientConfig: &tls.Config{RootCAs: certPool, InsecureSkipVerify: auth.skipSSLVerify},
 	}
 
 	// HTTP Redirects are authenticated by Go (>=1.8), when redirecting to an identical domain or a subdomain.
@@ -57,11 +62,75 @@ func mkHttpClient(url string, timeout time.Duration, auth authInfo, certPool *x5
 		}
 	}
 
-	return &httpClient{
+	client := &httpClient{
 		http.Client{Timeout: timeout, Transport: transport, CheckRedirect: redirectFunc},
 		url,
 		auth,
 	}
+
+	if auth.strictMode {
+		client.auth.token = authToken(client)
+	}
+
+	return client
+}
+
+func loginAuthToken(username string, privateKey string) string {
+	absPath, _ := filepath.Abs(privateKey)
+	signBytes, err := ioutil.ReadFile(absPath)
+	if err != nil {
+		log.Printf("Error reading private key %s: %s", absPath, err)
+		return ""
+	}
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM(signBytes)
+	if err != nil {
+		log.Printf("Error parsing privateKey %s: %s", absPath, err)
+	}
+
+	// Create the token
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"uid": username,
+	})
+	// Sign and get the complete encoded token as a string
+	tokenString, err := token.SignedString(signKey)
+	if err != nil {
+		log.Printf("Error creating login token %s: %s", token, err)
+		return ""
+	}
+	return tokenString
+}
+
+func authToken(httpClient *httpClient) string {
+	url := "https://master.mesos/acs/api/v1/auth/login"
+	loginToken := loginAuthToken(httpClient.auth.username, httpClient.auth.privateKey)
+	body, err := json.Marshal(&tokenRequest{UID: httpClient.auth.username, Token: loginToken})
+	if err != nil {
+		log.Printf("Error creating JSON request: %s", err)
+		return ""
+	}
+	buffer := bytes.NewBuffer(body)
+	req, err := http.NewRequest("POST", url, buffer)
+	if err != nil {
+		log.Printf("Error creating HTTP request to %s: %s", url, err)
+		return ""
+	}
+	req.Header.Add("Content-Type", "application/json")
+	res, err := httpClient.Do(req)
+	if err != nil {
+		log.Printf("Error fetching %s: %s", url, err)
+		errorCounter.Inc()
+		return ""
+	}
+	defer res.Body.Close()
+
+	var token tokenResponse
+	if err := json.NewDecoder(res.Body).Decode(&token); err != nil {
+		log.Printf("Error decoding response body from %s: %s", url, err)
+		errorCounter.Inc()
+		return ""
+	}
+
+	return fmt.Sprintf("token=%s", token.Token)
 }
 
 func csvInputToList(input string) []string {
@@ -83,15 +152,38 @@ func main() {
 	exportedTaskLabels := fs.String("exportedTaskLabels", "", "Comma-separated list of task labels to include in the corresponding metric")
 	exportedSlaveAttributes := fs.String("exportedSlaveAttributes", "", "Comma-separated list of slave attributes to include in the corresponding metric")
 	trustedCerts := fs.String("trustedCerts", "", "Comma-separated list of certificates (.pem files) trusted for requests to Mesos endpoints")
+	strictMode := fs.Bool("strictMode", false, "Use strict mode authentication")
+	username := fs.String("username", "", "Username for authentication")
+	password := fs.String("password", "", "Password for authentication")
+	privateKey := fs.String("privateKey", "", "Certificate for strict mode authentication")
+	skipSSLVerify := fs.Bool("skipSSLVerify", false, "Skip SSL certificate verification")
 
 	fs.Parse(os.Args[1:])
 	if *masterURL != "" && *slaveURL != "" {
 		log.Fatal("Only -master or -slave can be given at a time")
 	}
 
+	if *strictMode && *privateKey == "" {
+		log.Fatal("Must specify a private key when using strict mode authentiation!")
+		os.Exit(1)
+	}
+
 	auth := authInfo{
-		os.Getenv("MESOS_EXPORTER_USERNAME"),
-		os.Getenv("MESOS_EXPORTER_PASSWORD"),
+		strictMode: *strictMode,
+		skipSSLVerify: *skipSSLVerify,
+		privateKey: *privateKey,
+	}
+
+	if *username != "" {
+		auth.username = *username
+	} else {
+		auth.username = os.Getenv("MESOS_EXPORTER_USERNAME")
+	}
+
+	if *password != "" {
+		auth.password = *password
+	} else {
+		auth.password = os.Getenv("MESOS_EXPORTER_PASSWORD")
 	}
 
 	var certPool *x509.CertPool = nil

--- a/main.go
+++ b/main.go
@@ -115,12 +115,12 @@ func main() {
 	exportedTaskLabels := fs.String("exportedTaskLabels", "", "Comma-separated list of task labels to include in the corresponding metric")
 	exportedSlaveAttributes := fs.String("exportedSlaveAttributes", "", "Comma-separated list of slave attributes to include in the corresponding metric")
 	trustedCerts := fs.String("trustedCerts", "", "Comma-separated list of certificates (.pem files) trusted for requests to Mesos endpoints")
-	strictMode := fs.Bool("strictMode", false, "Use strict mode authentication")
+	strictMode := fs.Bool("dcosStrictMode", false, "Use DC/OS strict mode authentication")
 	username := fs.String("username", "", "Username for authentication")
 	password := fs.String("password", "", "Password for authentication")
-	loginURL := fs.String("loginURL", "https://leader.mesos/acs/api/v1/auth/login", "URL for strict mode authentication")
-	privateKey := fs.String("privateKey", "", "File path to certificate for strict mode authentication")
-	skipSSLVerify := fs.Bool("skipSSLVerify", false, "Skip SSL certificate verification")
+	loginURL := fs.String("dcosLoginURL", "https://leader.mesos/acs/api/v1/auth/login", "URL for DC/OS strict mode authentication")
+	privateKey := fs.String("dcosPrivateKey", "", "File path to certificate for strict mode authentication")
+	skipSSLVerify := fs.Bool("dcosSkipSSLVerify", false, "Skip SSL certificate verification during DC/OS authentication")
 
 	fs.Parse(os.Args[1:])
 	if *masterURL != "" && *slaveURL != "" {

--- a/master.go
+++ b/master.go
@@ -67,7 +67,7 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 		}): func(m metricMap, c prometheus.Collector) error {
 			elected, ok := m["master/elected"]
 			if !ok {
-				return notFoundInMap
+				return errNotFoundInMap
 			}
 			c.(prometheus.Gauge).Set(elected)
 			return nil
@@ -80,7 +80,7 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 		}): func(m metricMap, c prometheus.Collector) error {
 			uptime, ok := m["master/uptime_secs"]
 			if !ok {
-				return notFoundInMap
+				return errNotFoundInMap
 			}
 			c.(prometheus.Gauge).Set(uptime)
 			return nil

--- a/slave.go
+++ b/slave.go
@@ -65,7 +65,7 @@ func newSlaveCollector(httpClient *httpClient) prometheus.Collector {
 		}): func(m metricMap, c prometheus.Collector) error {
 			registered, ok := m["slave/registered"]
 			if !ok {
-				return notFoundInMap
+				return errNotFoundInMap
 			}
 			c.(prometheus.Gauge).Set(registered)
 			return nil
@@ -78,7 +78,7 @@ func newSlaveCollector(httpClient *httpClient) prometheus.Collector {
 		}): func(m metricMap, c prometheus.Collector) error {
 			uptime, ok := m["slave/uptime_secs"]
 			if !ok {
-				return notFoundInMap
+				return errNotFoundInMap
 			}
 			c.(prometheus.Gauge).Set(uptime)
 			return nil
@@ -103,7 +103,7 @@ func newSlaveCollector(httpClient *httpClient) prometheus.Collector {
 		}): func(m metricMap, c prometheus.Collector) error {
 			active, ok := m["slave/frameworks_active"]
 			if !ok {
-				return notFoundInMap
+				return errNotFoundInMap
 			}
 			c.(prometheus.Gauge).Set(active)
 			return nil
@@ -113,7 +113,7 @@ func newSlaveCollector(httpClient *httpClient) prometheus.Collector {
 			"Total number of executor terminations."): func(m metricMap, c prometheus.Collector) error {
 			terminated, ok := m["slave/executors_terminated"]
 			if !ok {
-				return notFoundInMap
+				return errNotFoundInMap
 			}
 			c.(*settableCounter).Set(terminated)
 			return nil
@@ -123,7 +123,7 @@ func newSlaveCollector(httpClient *httpClient) prometheus.Collector {
 			"Total number of executor preemptions."): func(m metricMap, c prometheus.Collector) error {
 			preempted, ok := m["slave/executors_preempted"]
 			if !ok {
-				return notFoundInMap
+				return errNotFoundInMap
 			}
 			c.(*settableCounter).Set(preempted)
 			return nil


### PR DESCRIPTION
This PR is based off @taharah's PR #40

I rebased and addressed @lloesche's feedback that DCOS -specific auth params ought to have `dcos` in their name.