### PR TITLE
Added a 'hostname' label to all master metrics.

### DIFF
--- a/main.go
+++ b/main.go
@@ -185,8 +185,14 @@ func main() {
 
 	switch {
 	case *masterURL != "":
+		hostname, err := os.Hostname()
+		if err != nil {
+			log.Fatal("Unable to get the hostname of this machine")
+		}
 		for _, f := range []func(*httpClient) prometheus.Collector{
-			newMasterCollector,
+			func(c *httpClient) prometheus.Collector {
+				return newMasterCollector(c, hostname)
+			},
 			func(c *httpClient) prometheus.Collector {
 				return newMasterStateCollector(c, slaveAttributeLabels)
 			},

--- a/master.go
+++ b/master.go
@@ -8,10 +8,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func newMasterCollector(httpClient *httpClient) prometheus.Collector {
+func newMasterCollector(httpClient *httpClient, hostname string) prometheus.Collector {
 	metrics := map[prometheus.Collector]func(metricMap, prometheus.Collector) error{
 		// CPU/Disk/Mem resources in free/used
-		gauge("master", "cpus", "Current CPU resources in cluster.", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "cpus", "Current CPU resources in cluster.", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			percent, ok := m["master/cpus_percent"]
 			if !ok {
 				log.WithField("metric", "master/cpus_percent").Warn(LogErrNotFoundInMap)
@@ -24,13 +24,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/cpus_used").Warn(LogErrNotFoundInMap)
 			}
-			c.(*prometheus.GaugeVec).WithLabelValues("percent").Set(percent)
-			c.(*prometheus.GaugeVec).WithLabelValues("total").Set(total)
-			c.(*prometheus.GaugeVec).WithLabelValues("free").Set(total - used)
-			c.(*prometheus.GaugeVec).WithLabelValues("used").Set(used)
+			c.(*prometheus.GaugeVec).WithLabelValues("percent", hostname).Set(percent)
+			c.(*prometheus.GaugeVec).WithLabelValues("total", hostname).Set(total)
+			c.(*prometheus.GaugeVec).WithLabelValues("free", hostname).Set(total - used)
+			c.(*prometheus.GaugeVec).WithLabelValues("used", hostname).Set(used)
 			return nil
 		},
-		gauge("master", "cpus_revocable", "Current revocable CPU resources in cluster.", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "cpus_revocable", "Current revocable CPU resources in cluster.", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			percent, ok := m["master/cpus_revocable_percent"]
 			if !ok {
 				log.WithField("metric", "master/cpus_revocable_percent").Warn(LogErrNotFoundInMap)
@@ -43,13 +43,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/cpus_revocable_used").Warn(LogErrNotFoundInMap)
 			}
-			c.(*prometheus.GaugeVec).WithLabelValues("percent").Set(percent)
-			c.(*prometheus.GaugeVec).WithLabelValues("total").Set(total)
-			c.(*prometheus.GaugeVec).WithLabelValues("free").Set(total - used)
-			c.(*prometheus.GaugeVec).WithLabelValues("used").Set(used)
+			c.(*prometheus.GaugeVec).WithLabelValues("percent", hostname).Set(percent)
+			c.(*prometheus.GaugeVec).WithLabelValues("total", hostname).Set(total)
+			c.(*prometheus.GaugeVec).WithLabelValues("free", hostname).Set(total - used)
+			c.(*prometheus.GaugeVec).WithLabelValues("used", hostname).Set(used)
 			return nil
 		},
-		gauge("master", "gpus", "Current GPU resources in cluster.", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "gpus", "Current GPU resources in cluster.", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			percent, ok := m["master/gpus_percent"]
 			if !ok {
 				log.WithField("metric", "master/gpus_percent").Warn(LogErrNotFoundInMap)
@@ -62,13 +62,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/gpus_used").Warn(LogErrNotFoundInMap)
 			}
-			c.(*prometheus.GaugeVec).WithLabelValues("percent").Set(percent)
-			c.(*prometheus.GaugeVec).WithLabelValues("total").Set(total)
-			c.(*prometheus.GaugeVec).WithLabelValues("free").Set(total - used)
-			c.(*prometheus.GaugeVec).WithLabelValues("used").Set(used)
+			c.(*prometheus.GaugeVec).WithLabelValues("percent", hostname).Set(percent)
+			c.(*prometheus.GaugeVec).WithLabelValues("total", hostname).Set(total)
+			c.(*prometheus.GaugeVec).WithLabelValues("free", hostname).Set(total - used)
+			c.(*prometheus.GaugeVec).WithLabelValues("used", hostname).Set(used)
 			return nil
 		},
-		gauge("master", "gpus_revocable", "Current revocable GPU resources in cluster.", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "gpus_revocable", "Current revocable GPU resources in cluster.", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			percent, ok := m["master/gpus_revocable_percent"]
 			if !ok {
 				log.WithField("metric", "master/gpus_revocable_percent").Warn(LogErrNotFoundInMap)
@@ -81,13 +81,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/gpus_revocable_used").Warn(LogErrNotFoundInMap)
 			}
-			c.(*prometheus.GaugeVec).WithLabelValues("percent").Set(percent)
-			c.(*prometheus.GaugeVec).WithLabelValues("total").Set(total)
-			c.(*prometheus.GaugeVec).WithLabelValues("free").Set(total - used)
-			c.(*prometheus.GaugeVec).WithLabelValues("used").Set(used)
+			c.(*prometheus.GaugeVec).WithLabelValues("percent", hostname).Set(percent)
+			c.(*prometheus.GaugeVec).WithLabelValues("total", hostname).Set(total)
+			c.(*prometheus.GaugeVec).WithLabelValues("free", hostname).Set(total - used)
+			c.(*prometheus.GaugeVec).WithLabelValues("used", hostname).Set(used)
 			return nil
 		},
-		gauge("master", "mem", "Current memory resources in cluster.", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "mem", "Current memory resources in cluster.", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			percent, ok := m["master/mem_percent"]
 			if !ok {
 				log.WithField("metric", "master/mem_percent").Warn(LogErrNotFoundInMap)
@@ -100,13 +100,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/mem_used").Warn(LogErrNotFoundInMap)
 			}
-			c.(*prometheus.GaugeVec).WithLabelValues("percent").Set(percent)
-			c.(*prometheus.GaugeVec).WithLabelValues("total").Set(total)
-			c.(*prometheus.GaugeVec).WithLabelValues("free").Set(total - used)
-			c.(*prometheus.GaugeVec).WithLabelValues("used").Set(used)
+			c.(*prometheus.GaugeVec).WithLabelValues("percent", hostname).Set(percent)
+			c.(*prometheus.GaugeVec).WithLabelValues("total", hostname).Set(total)
+			c.(*prometheus.GaugeVec).WithLabelValues("free", hostname).Set(total - used)
+			c.(*prometheus.GaugeVec).WithLabelValues("used", hostname).Set(used)
 			return nil
 		},
-		gauge("master", "mem_revocable", "Current revocable memory resources in cluster.", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "mem_revocable", "Current revocable memory resources in cluster.", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			percent, ok := m["master/mem_revocable_percent"]
 			if !ok {
 				log.WithField("metric", "master/mem_revocable_percent").Warn(LogErrNotFoundInMap)
@@ -119,13 +119,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/mem_revocable_used").Warn(LogErrNotFoundInMap)
 			}
-			c.(*prometheus.GaugeVec).WithLabelValues("percent").Set(percent)
-			c.(*prometheus.GaugeVec).WithLabelValues("total").Set(total)
-			c.(*prometheus.GaugeVec).WithLabelValues("free").Set(total - used)
-			c.(*prometheus.GaugeVec).WithLabelValues("used").Set(used)
+			c.(*prometheus.GaugeVec).WithLabelValues("percent", hostname).Set(percent)
+			c.(*prometheus.GaugeVec).WithLabelValues("total", hostname).Set(total)
+			c.(*prometheus.GaugeVec).WithLabelValues("free", hostname).Set(total - used)
+			c.(*prometheus.GaugeVec).WithLabelValues("used", hostname).Set(used)
 			return nil
 		},
-		gauge("master", "disk", "Current disk resources in cluster.", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "disk", "Current disk resources in cluster.", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			percent, ok := m["master/disk_percent"]
 			if !ok {
 				log.WithField("metric", "master/disk_percent").Warn(LogErrNotFoundInMap)
@@ -138,13 +138,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/disk_used").Warn(LogErrNotFoundInMap)
 			}
-			c.(*prometheus.GaugeVec).WithLabelValues("percent").Set(percent)
-			c.(*prometheus.GaugeVec).WithLabelValues("total").Set(total)
-			c.(*prometheus.GaugeVec).WithLabelValues("free").Set(total - used)
-			c.(*prometheus.GaugeVec).WithLabelValues("used").Set(used)
+			c.(*prometheus.GaugeVec).WithLabelValues("percent", hostname).Set(percent)
+			c.(*prometheus.GaugeVec).WithLabelValues("total", hostname).Set(total)
+			c.(*prometheus.GaugeVec).WithLabelValues("free", hostname).Set(total - used)
+			c.(*prometheus.GaugeVec).WithLabelValues("used", hostname).Set(used)
 			return nil
 		},
-		gauge("master", "disk_revocable", "Current disk resources in cluster.", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "disk_revocable", "Current disk resources in cluster.", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			percent, ok := m["master/disk_revocable_percent"]
 			if !ok {
 				log.WithField("metric", "master/disk_revocable_percent").Warn(LogErrNotFoundInMap)
@@ -157,41 +157,41 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/disk_revocable_used").Warn(LogErrNotFoundInMap)
 			}
-			c.(*prometheus.GaugeVec).WithLabelValues("percent").Set(percent)
-			c.(*prometheus.GaugeVec).WithLabelValues("total").Set(total)
-			c.(*prometheus.GaugeVec).WithLabelValues("free").Set(total - used)
-			c.(*prometheus.GaugeVec).WithLabelValues("used").Set(used)
+			c.(*prometheus.GaugeVec).WithLabelValues("percent", hostname).Set(percent)
+			c.(*prometheus.GaugeVec).WithLabelValues("total", hostname).Set(total)
+			c.(*prometheus.GaugeVec).WithLabelValues("free", hostname).Set(total - used)
+			c.(*prometheus.GaugeVec).WithLabelValues("used", hostname).Set(used)
 			return nil
 		},
 		// Master stats about uptime and election state
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "master",
 			Name:      "elected",
 			Help:      "1 if master is elected leader, 0 if not",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			elected, ok := m["master/elected"]
 			if !ok {
 				log.WithField("metric", "master/elected").Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(elected)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(elected)
 			return nil
 		},
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "master",
 			Name:      "uptime_seconds",
 			Help:      "Number of seconds the master process is running.",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			uptime, ok := m["master/uptime_secs"]
 			if !ok {
 				log.WithField("metric", "master/uptime_secs").Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(uptime)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(uptime)
 			return nil
 		},
 		// Master stats about agents
-		counter("master", "slave_registration_events_total", "Total number of registration events on this master since it booted.", "event"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "slave_registration_events_total", "Total number of registration events on this master since it booted.", "event", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			registrations, ok := m["master/slave_registrations"]
 			if !ok {
 				log.WithField("metric", "master/slave_registrations").Warn(LogErrNotFoundInMap)
@@ -200,21 +200,21 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/slave_reregistrations").Warn(LogErrNotFoundInMap)
 			}
-			c.(*settableCounterVec).Set(registrations, "register")
-			c.(*settableCounterVec).Set(reregistrations, "reregister")
+			c.(*settableCounterVec).Set(registrations, "register", hostname)
+			c.(*settableCounterVec).Set(reregistrations, "reregister", hostname)
 			return nil
 		},
 
-		counter("master", "recovery_slave_removal_events_total", "Total number of recovery removal events on this master since it booted.", "event"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "recovery_slave_removal_events_total", "Total number of recovery removal events on this master since it booted.", "event", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			removals, ok := m["master/recovery_slave_removals"]
 			if !ok {
 				log.WithField("metric", "master/recovery_slave_removals").Warn(LogErrNotFoundInMap)
 			}
-			c.(*settableCounterVec).Set(removals, "removal")
+			c.(*settableCounterVec).Set(removals, "removal", hostname)
 			return nil
 		},
 
-		counter("master", "slave_removal_events_total", "Total number of removal events on this master since it booted.", "event"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "slave_removal_events_total", "Total number of removal events on this master since it booted.", "event", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			scheduled, ok := m["master/slave_shutdowns_scheduled"]
 			if !ok {
 				log.WithField("metric", "master/slave_shutdowns_scheduled").Warn(LogErrNotFoundInMap)
@@ -231,15 +231,15 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/slave_removals").Warn(LogErrNotFoundInMap)
 			}
-			c.(*settableCounterVec).Set(scheduled, "scheduled")
-			c.(*settableCounterVec).Set(canceled, "canceled")
-			c.(*settableCounterVec).Set(completed, "completed")
+			c.(*settableCounterVec).Set(scheduled, "scheduled", hostname)
+			c.(*settableCounterVec).Set(canceled, "canceled", hostname)
+			c.(*settableCounterVec).Set(completed, "completed", hostname)
 			// set this explicitly to be more obvious
 			died := removals - completed
-			c.(*settableCounterVec).Set(died, "died")
+			c.(*settableCounterVec).Set(died, "died", hostname)
 			return nil
 		},
-		counter("master", "slave_removal_events_reasons", "Total number of slave removal events by reason on this master since it booted.", "reason"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "slave_removal_events_reasons", "Total number of slave removal events by reason on this master since it booted.", "reason", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, err := regexp.Compile("master/slave_removals/reason_(.*?)$")
 			if err != nil {
 				log.WithFields(log.Fields{
@@ -255,11 +255,11 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 					continue
 				}
 				reason := matches[1]
-				c.(*settableCounterVec).Set(value, reason)
+				c.(*settableCounterVec).Set(value, reason, hostname)
 			}
 			return nil
 		},
-		counter("master", "slave_unreachable_events_total", "Total number of slave unreachable events on this master since it booted.", "event"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "slave_unreachable_events_total", "Total number of slave unreachable events on this master since it booted.", "event", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			canceled, ok := m["master/slave_unreachable_canceled"]
 			if !ok {
 				log.WithField("metric", "master/slave_unreachable_canceled").Warn(LogErrNotFoundInMap)
@@ -272,13 +272,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/slave_unreachable_scheduled").Warn(LogErrNotFoundInMap)
 			}
-			c.(*settableCounterVec).Set(canceled, "canceled")
-			c.(*settableCounterVec).Set(completed, "completed")
-			c.(*settableCounterVec).Set(scheduled, "scheduled")
+			c.(*settableCounterVec).Set(canceled, "canceled", hostname)
+			c.(*settableCounterVec).Set(completed, "completed", hostname)
+			c.(*settableCounterVec).Set(scheduled, "scheduled", hostname)
 			return nil
 		},
 
-		gauge("master", "slaves_state", "Current number of slaves known to the master per connection and registration state.", "state"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "slaves_state", "Current number of slaves known to the master per connection and registration state.", "state", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			active, ok := m["master/slaves_active"]
 			if !ok {
 				log.WithField("metric", "master/slaves_active").Warn(LogErrNotFoundInMap)
@@ -298,18 +298,18 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 
 			// FIXME: Make sure those assumptions are right
 			// Every "active" node is connected to the master
-			c.(*prometheus.GaugeVec).WithLabelValues("connected_active").Set(active)
+			c.(*prometheus.GaugeVec).WithLabelValues("connected_active", hostname).Set(active)
 			// Every "inactive" node is connected but node sending offers
-			c.(*prometheus.GaugeVec).WithLabelValues("connected_inactive").Set(inactive)
+			c.(*prometheus.GaugeVec).WithLabelValues("connected_inactive", hostname).Set(inactive)
 			// Every "disconnected" node is "inactive"
-			c.(*prometheus.GaugeVec).WithLabelValues("disconnected_inactive").Set(disconnected)
+			c.(*prometheus.GaugeVec).WithLabelValues("disconnected_inactive", hostname).Set(disconnected)
 			// Every "connected" node is either active or inactive
-			c.(*prometheus.GaugeVec).WithLabelValues("unreachable").Set(unreachable)
+			c.(*prometheus.GaugeVec).WithLabelValues("unreachable", hostname).Set(unreachable)
 			return nil
 		},
 
 		// Master stats about frameworks
-		gauge("master", "frameworks_state", "Current number of frames known to the master per connection and registration state.", "state"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "frameworks_state", "Current number of frames known to the master per connection and registration state.", "state", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			active, ok := m["master/frameworks_active"]
 			if !ok {
 				log.WithField("metric", "master/frameworks_active").Warn(LogErrNotFoundInMap)
@@ -324,30 +324,30 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			}
 			// FIXME: Make sure those assumptions are right
 			// Every "active" framework is connected to the master
-			c.(*prometheus.GaugeVec).WithLabelValues("connected_active").Set(active)
+			c.(*prometheus.GaugeVec).WithLabelValues("connected_active", hostname).Set(active)
 			// Every "inactive" framework is connected but framework sending offers
-			c.(*prometheus.GaugeVec).WithLabelValues("connected_inactive").Set(inactive)
+			c.(*prometheus.GaugeVec).WithLabelValues("connected_inactive", hostname).Set(inactive)
 			// Every "disconnected" framework is "inactive"
-			c.(*prometheus.GaugeVec).WithLabelValues("disconnected_inactive").Set(disconnected)
+			c.(*prometheus.GaugeVec).WithLabelValues("disconnected_inactive", hostname).Set(disconnected)
 			// Every "connected" framework is either active or inactive
 			return nil
 		},
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "master",
 			Name:      "offers_pending",
 			Help:      "Current number of offers made by the master which aren't yet accepted or declined by frameworks.",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			offers, ok := m["master/outstanding_offers"]
 			if !ok {
 				log.WithField("metric", "master/outstanding_offers").Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(offers)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(offers)
 			return nil
 		},
 
 		// Master stats about tasks
-		counter("master", "task_states_exit_total", "Total number of tasks processed by exit state.", "state"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "task_states_exit_total", "Total number of tasks processed by exit state.", "state", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			dropped, ok := m["master/tasks_dropped"]
 			if !ok {
 				log.WithField("metric", "master/tasks_dropped").Warn(LogErrNotFoundInMap)
@@ -384,19 +384,19 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/tasks_lost").Warn(LogErrNotFoundInMap)
 			}
-			c.(*settableCounterVec).Set(dropped, "dropped")
-			c.(*settableCounterVec).Set(errored, "errored")
-			c.(*settableCounterVec).Set(failed, "failed")
-			c.(*settableCounterVec).Set(finished, "finished")
-			c.(*settableCounterVec).Set(gone, "gone")
-			c.(*settableCounterVec).Set(goneByOperator, "gone_by_operator")
-			c.(*settableCounterVec).Set(killed, "killed")
-			c.(*settableCounterVec).Set(killing, "killing")
-			c.(*settableCounterVec).Set(lost, "lost")
+			c.(*settableCounterVec).Set(dropped, "dropped", hostname)
+			c.(*settableCounterVec).Set(errored, "errored", hostname)
+			c.(*settableCounterVec).Set(failed, "failed", hostname)
+			c.(*settableCounterVec).Set(finished, "finished", hostname)
+			c.(*settableCounterVec).Set(gone, "gone", hostname)
+			c.(*settableCounterVec).Set(goneByOperator, "gone_by_operator", hostname)
+			c.(*settableCounterVec).Set(killed, "killed", hostname)
+			c.(*settableCounterVec).Set(killing, "killing", hostname)
+			c.(*settableCounterVec).Set(lost, "lost", hostname)
 			return nil
 		},
 
-		counter("master", "task_states_current", "Current number of tasks by state.", "state"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "task_states_current", "Current number of tasks by state.", "state", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			running, ok := m["master/tasks_running"]
 			if !ok {
 				log.WithField("metric", "master/tasks_running").Warn(LogErrNotFoundInMap)
@@ -413,14 +413,14 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/tasks_unreachable").Warn(LogErrNotFoundInMap)
 			}
-			c.(*settableCounterVec).Set(running, "running")
-			c.(*settableCounterVec).Set(staging, "staging")
-			c.(*settableCounterVec).Set(starting, "starting")
-			c.(*settableCounterVec).Set(unreachable, "unreachable")
+			c.(*settableCounterVec).Set(running, "running", hostname)
+			c.(*settableCounterVec).Set(staging, "staging", hostname)
+			c.(*settableCounterVec).Set(starting, "starting", hostname)
+			c.(*settableCounterVec).Set(unreachable, "unreachable", hostname)
 			return nil
 		},
 
-		counter("master", "task_state_counts_by_source_reason", "Number of task states by source and reason", "state", "source", "reason"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "task_state_counts_by_source_reason", "Number of task states by source and reason", "state", "source", "reason", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, err := regexp.Compile("master/task_(.*?)/source_(.*?)/reason_(.*?)$")
 			if err != nil {
 				log.WithFields(log.Fields{
@@ -438,13 +438,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				state := matches[1]
 				source := matches[2]
 				reason := matches[3]
-				c.(*settableCounterVec).Set(value, state, source, reason)
+				c.(*settableCounterVec).Set(value, state, source, reason, hostname)
 			}
 			return nil
 		},
 
 		// Master stats about messages
-		counter("master", "messages", "Number of messages by the master by state", "type"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "messages", "Number of messages by the master by state", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			droppedMessages, ok := m["master/dropped_messages"]
 			if !ok {
 				log.WithField("metric", "master/dropped_messages").Warn(LogErrNotFoundInMap)
@@ -534,34 +534,34 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				log.WithField("metric", "master/messages_update_slave").Warn(LogErrNotFoundInMap)
 			}
 
-			c.(*settableCounterVec).Set(authenticateMessages, "authenticate_messages")
-			c.(*settableCounterVec).Set(droppedMessages, "dropped_messages")
-			c.(*settableCounterVec).Set(deactivateFrameworkMessages, "deactivate_framework")
-			c.(*settableCounterVec).Set(declineOfferMessages, "decline_offers")
-			c.(*settableCounterVec).Set(executorToFrameworkMessages, "executor_to_framework")
-			c.(*settableCounterVec).Set(exitedExecutor, "exited_executor")
-			c.(*settableCounterVec).Set(frameworkToExecutor, "framework_to_executor")
-			c.(*settableCounterVec).Set(killTask, "kill_task")
-			c.(*settableCounterVec).Set(launchTasks, "launch_tasks")
-			c.(*settableCounterVec).Set(reconcileTasks, "reconcile_tasks")
-			c.(*settableCounterVec).Set(registerFramework, "register_framework")
-			c.(*settableCounterVec).Set(registerSlave, "register_slave")
-			c.(*settableCounterVec).Set(reregisterFramework, "reregister_framework")
-			c.(*settableCounterVec).Set(reregisterSlave, "reregister_slave")
-			c.(*settableCounterVec).Set(resourceRequest, "resource_request")
-			c.(*settableCounterVec).Set(reviveOffers, "revive_offers")
-			c.(*settableCounterVec).Set(statusUpdate, "status_update")
-			c.(*settableCounterVec).Set(statusUpdateAck, "status_update_acknowledgement")
-			c.(*settableCounterVec).Set(suppressOffers, "suppress_offers")
-			c.(*settableCounterVec).Set(unregisterFramework, "unregister_framework")
-			c.(*settableCounterVec).Set(unregisterSlave, "unregister_slave")
-			c.(*settableCounterVec).Set(updateSlave, "update_slave")
+			c.(*settableCounterVec).Set(authenticateMessages, "authenticate_messages", hostname)
+			c.(*settableCounterVec).Set(droppedMessages, "dropped_messages", hostname)
+			c.(*settableCounterVec).Set(deactivateFrameworkMessages, "deactivate_framework", hostname)
+			c.(*settableCounterVec).Set(declineOfferMessages, "decline_offers", hostname)
+			c.(*settableCounterVec).Set(executorToFrameworkMessages, "executor_to_framework", hostname)
+			c.(*settableCounterVec).Set(exitedExecutor, "exited_executor", hostname)
+			c.(*settableCounterVec).Set(frameworkToExecutor, "framework_to_executor", hostname)
+			c.(*settableCounterVec).Set(killTask, "kill_task", hostname)
+			c.(*settableCounterVec).Set(launchTasks, "launch_tasks", hostname)
+			c.(*settableCounterVec).Set(reconcileTasks, "reconcile_tasks", hostname)
+			c.(*settableCounterVec).Set(registerFramework, "register_framework", hostname)
+			c.(*settableCounterVec).Set(registerSlave, "register_slave", hostname)
+			c.(*settableCounterVec).Set(reregisterFramework, "reregister_framework", hostname)
+			c.(*settableCounterVec).Set(reregisterSlave, "reregister_slave", hostname)
+			c.(*settableCounterVec).Set(resourceRequest, "resource_request", hostname)
+			c.(*settableCounterVec).Set(reviveOffers, "revive_offers", hostname)
+			c.(*settableCounterVec).Set(statusUpdate, "status_update", hostname)
+			c.(*settableCounterVec).Set(statusUpdateAck, "status_update_acknowledgement", hostname)
+			c.(*settableCounterVec).Set(suppressOffers, "suppress_offers", hostname)
+			c.(*settableCounterVec).Set(unregisterFramework, "unregister_framework", hostname)
+			c.(*settableCounterVec).Set(unregisterSlave, "unregister_slave", hostname)
+			c.(*settableCounterVec).Set(updateSlave, "update_slave", hostname)
 			return nil
 		},
 
 		counter("master", "messages_outcomes_total",
 			"Total number of messages by outcome of operation and direction.",
-			"source", "destination", "type", "outcome"): func(m metricMap, c prometheus.Collector) error {
+			"source", "destination", "type", "outcome", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			frameworkToExecutorValid, ok := m["master/valid_framework_to_executor_messages"]
 			if !ok {
 				log.WithField("metric", "master/valid_framework_to_executor_messages").Warn(LogErrNotFoundInMap)
@@ -597,21 +597,21 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/invalid_status_updates").Warn(LogErrNotFoundInMap)
 			}
-			c.(*settableCounterVec).Set(frameworkToExecutorValid, "framework", "executor", "", "valid")
-			c.(*settableCounterVec).Set(frameworkToExecutorInvalid, "framework", "executor", "", "invalid")
+			c.(*settableCounterVec).Set(frameworkToExecutorValid, "framework", "executor", "", "valid", hostname)
+			c.(*settableCounterVec).Set(frameworkToExecutorInvalid, "framework", "executor", "", "invalid", hostname)
 
-			c.(*settableCounterVec).Set(executorToFrameworkValid, "executor", "framework", "", "valid")
-			c.(*settableCounterVec).Set(executorToFrameworkInvalid, "executor", "framework", "", "invalid")
+			c.(*settableCounterVec).Set(executorToFrameworkValid, "executor", "framework", "", "valid", hostname)
+			c.(*settableCounterVec).Set(executorToFrameworkInvalid, "executor", "framework", "", "invalid", hostname)
 
 			// We consider a ack message simply as a message from slave to framework
-			c.(*settableCounterVec).Set(statusUpdateValid, "framework", "slave", "status_update", "valid")
-			c.(*settableCounterVec).Set(statusUpdateInvalid, "framework", "slave", "status_update", "invalid")
-			c.(*settableCounterVec).Set(statusUpdateAckValid, "slave", "framework", "status_update", "valid")
-			c.(*settableCounterVec).Set(statusUpdateAckInvalid, "slave", "framework", "status_update", "invalid")
+			c.(*settableCounterVec).Set(statusUpdateValid, "framework", "slave", "status_update", "valid", hostname)
+			c.(*settableCounterVec).Set(statusUpdateInvalid, "framework", "slave", "status_update", "invalid", hostname)
+			c.(*settableCounterVec).Set(statusUpdateAckValid, "slave", "framework", "status_update", "valid", hostname)
+			c.(*settableCounterVec).Set(statusUpdateAckInvalid, "slave", "framework", "status_update", "invalid", hostname)
 			return nil
 		},
 		// Master stats about events
-		gauge("master", "event_queue_length", "Current number of elements in event queue by type", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "event_queue_length", "Current number of elements in event queue by type", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			dispatches, ok := m["master/event_queue_dispatches"]
 			if !ok {
 				log.WithField("metric", "master/event_queue_dispatches").Warn(LogErrNotFoundInMap)
@@ -624,42 +624,42 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "master/event_queue_messages").Warn(LogErrNotFoundInMap)
 			}
-			c.(*prometheus.GaugeVec).WithLabelValues("message").Set(messages)
-			c.(*prometheus.GaugeVec).WithLabelValues("http_request").Set(httpRequests)
-			c.(*prometheus.GaugeVec).WithLabelValues("dispatches").Set(dispatches)
+			c.(*prometheus.GaugeVec).WithLabelValues("message", hostname).Set(messages)
+			c.(*prometheus.GaugeVec).WithLabelValues("http_request", hostname).Set(httpRequests)
+			c.(*prometheus.GaugeVec).WithLabelValues("dispatches", hostname).Set(dispatches)
 			return nil
 		},
 
 		// Master stats about allocations
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "master",
 			Name:      "allocator_event_queue_dispatches",
 			Help:      "Number of dispatch events in the allocator event queue.",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			count, ok := m["allocator/event_queue_dispatches"]
 			if !ok {
 				log.WithField("metric", "allocator/event_queue_dispatches").Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(count)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(count)
 			return nil
 		},
 
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "master",
 			Name:      "allocation_run_ms_count",
 			Help:      "Number of allocation algorithm time measurements in the window",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			count, ok := m["allocator/mesos/allocation_runs"]
 			if !ok {
 				log.WithField("metric", "allocator/mesos/allocation_runs").Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(count)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(count)
 			return nil
 		},
 
-		gauge("master", "allocation_run_ms", "Time spent in allocation algorithm in ms.", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "allocation_run_ms", "Time spent in allocation algorithm in ms.", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			mean, ok := m["allocator/mesos/allocation_run_ms"]
 			if !ok {
 				log.WithField("metric", "allocator/mesos/allocation_run_ms").Warn(LogErrNotFoundInMap)
@@ -696,37 +696,37 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "allocator/mesos/allocation_run_ms/p9999").Warn(LogErrNotFoundInMap)
 			}
-			c.(*prometheus.GaugeVec).WithLabelValues("mean").Set(mean)
-			c.(*prometheus.GaugeVec).WithLabelValues("min").Set(min)
-			c.(*prometheus.GaugeVec).WithLabelValues("max").Set(max)
-			c.(*prometheus.GaugeVec).WithLabelValues("p50").Set(p50)
-			c.(*prometheus.GaugeVec).WithLabelValues("p90").Set(p90)
-			c.(*prometheus.GaugeVec).WithLabelValues("p95").Set(p95)
-			c.(*prometheus.GaugeVec).WithLabelValues("p99").Set(p99)
-			c.(*prometheus.GaugeVec).WithLabelValues("p999").Set(p999)
-			c.(*prometheus.GaugeVec).WithLabelValues("p9999").Set(p9999)
+			c.(*prometheus.GaugeVec).WithLabelValues("mean", hostname).Set(mean)
+			c.(*prometheus.GaugeVec).WithLabelValues("min", hostname).Set(min)
+			c.(*prometheus.GaugeVec).WithLabelValues("max", hostname).Set(max)
+			c.(*prometheus.GaugeVec).WithLabelValues("p50", hostname).Set(p50)
+			c.(*prometheus.GaugeVec).WithLabelValues("p90", hostname).Set(p90)
+			c.(*prometheus.GaugeVec).WithLabelValues("p95", hostname).Set(p95)
+			c.(*prometheus.GaugeVec).WithLabelValues("p99", hostname).Set(p99)
+			c.(*prometheus.GaugeVec).WithLabelValues("p999", hostname).Set(p999)
+			c.(*prometheus.GaugeVec).WithLabelValues("p9999", hostname).Set(p9999)
 			return nil
 		},
 
-		counter("master", "allocation_runs", "Number of times the allocation alorithm has run", "event"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "allocation_runs", "Number of times the allocation alorithm has run", "event", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			runs, ok := m["allocator/mesos/allocation_runs"]
 			if !ok {
 				log.WithField("metric", "allocator/mesos/allocation_runs").Warn(LogErrNotFoundInMap)
 			}
-			c.(*settableCounterVec).Set(runs, "allocation")
+			c.(*settableCounterVec).Set(runs, "allocation", hostname)
 			return nil
 		},
 
-		counter("master", "allocation_run_latency_ms_count", "Number of allocation batch latency measurements", "event"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "allocation_run_latency_ms_count", "Number of allocation batch latency measurements", "event", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			count, ok := m["allocator/mesos/allocation_run_latency_ms/count"]
 			if !ok {
 				log.WithField("metric", "allocator/mesos/allocation_run_latency_ms/count").Warn(LogErrNotFoundInMap)
 			}
-			c.(*settableCounterVec).Set(count, "allocation")
+			c.(*settableCounterVec).Set(count, "allocation", hostname)
 			return nil
 		},
 
-		gauge("master", "allocation_run_latency_ms", "Allocation batch latency in ms.", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "allocation_run_latency_ms", "Allocation batch latency in ms.", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			mean, ok := m["allocator/mesos/allocation_run_latency_ms"]
 			if !ok {
 				log.WithField("metric", "allocator/mesos/allocation_run_latency_ms").Warn(LogErrNotFoundInMap)
@@ -763,32 +763,32 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 			if !ok {
 				log.WithField("metric", "allocator/mesos/allocation_run_latency_ms/p9999").Warn(LogErrNotFoundInMap)
 			}
-			c.(*prometheus.GaugeVec).WithLabelValues("mean").Set(mean)
-			c.(*prometheus.GaugeVec).WithLabelValues("min").Set(min)
-			c.(*prometheus.GaugeVec).WithLabelValues("max").Set(max)
-			c.(*prometheus.GaugeVec).WithLabelValues("p50").Set(p50)
-			c.(*prometheus.GaugeVec).WithLabelValues("p90").Set(p90)
-			c.(*prometheus.GaugeVec).WithLabelValues("p95").Set(p95)
-			c.(*prometheus.GaugeVec).WithLabelValues("p99").Set(p99)
-			c.(*prometheus.GaugeVec).WithLabelValues("p999").Set(p999)
-			c.(*prometheus.GaugeVec).WithLabelValues("p9999").Set(p9999)
+			c.(*prometheus.GaugeVec).WithLabelValues("mean", hostname).Set(mean)
+			c.(*prometheus.GaugeVec).WithLabelValues("min", hostname).Set(min)
+			c.(*prometheus.GaugeVec).WithLabelValues("max", hostname).Set(max)
+			c.(*prometheus.GaugeVec).WithLabelValues("p50", hostname).Set(p50)
+			c.(*prometheus.GaugeVec).WithLabelValues("p90", hostname).Set(p90)
+			c.(*prometheus.GaugeVec).WithLabelValues("p95", hostname).Set(p95)
+			c.(*prometheus.GaugeVec).WithLabelValues("p99", hostname).Set(p99)
+			c.(*prometheus.GaugeVec).WithLabelValues("p999", hostname).Set(p999)
+			c.(*prometheus.GaugeVec).WithLabelValues("p9999", hostname).Set(p9999)
 			return nil
 		},
 
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "master",
 			Name:      "event_queue_dispatches",
 			Help:      "Number of dispatch events in the allocator mesos event queue.",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			count, ok := m["allocator/mesos/event_queue_dispatches"]
 			if !ok {
 				log.WithField("metric", "allocator/mesos/event_queue_dispatches").Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(count)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(count)
 			return nil
 		},
-		gauge("master", "allocator_offer_filters_active", "Number of active offer filters for all frameworks within the role", "role"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "allocator_offer_filters_active", "Number of active offer filters for all frameworks within the role", "role", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, err := regexp.Compile("allocator/mesos/offer_filters/roles/(.*?)/active")
 			if err != nil {
 				log.WithFields(log.Fields{
@@ -804,12 +804,12 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 					continue
 				}
 				role := matches[1]
-				c.(*prometheus.GaugeVec).WithLabelValues(role).Set(value)
+				c.(*prometheus.GaugeVec).WithLabelValues(role, hostname).Set(value)
 			}
 			return nil
 		},
 
-		gauge("master", "allocator_role_quota_offered_or_allocated", "Amount of resources considered offered or allocated towards a role's quota guarantee.", "role", "resource"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "allocator_role_quota_offered_or_allocated", "Amount of resources considered offered or allocated towards a role's quota guarantee.", "role", "resource", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, err := regexp.Compile("allocator/mesos/quota/roles/(.*?)/resources/(.*?)/offered_or_allocated")
 			if err != nil {
 				log.WithFields(log.Fields{
@@ -826,12 +826,12 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				}
 				role := matches[1]
 				resource := matches[2]
-				c.(*prometheus.GaugeVec).WithLabelValues(role, resource).Set(value)
+				c.(*prometheus.GaugeVec).WithLabelValues(role, resource, hostname).Set(value)
 			}
 			return nil
 		},
 
-		gauge("master", "allocator_role_shares_dominant", "Dominance factor for a role", "role"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "allocator_role_shares_dominant", "Dominance factor for a role", "role", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, err := regexp.Compile("allocator/mesos/roles/(.*?)/shares/dominant")
 			if err != nil {
 				log.WithFields(log.Fields{
@@ -847,12 +847,12 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 					continue
 				}
 				role := matches[1]
-				c.(*prometheus.GaugeVec).WithLabelValues(role).Set(value)
+				c.(*prometheus.GaugeVec).WithLabelValues(role, hostname).Set(value)
 			}
 			return nil
 		},
 
-		gauge("master", "allocator_role_quota_guarantee", "Amount of resources guaranteed for a role via quota", "role", "resource"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "allocator_role_quota_guarantee", "Amount of resources guaranteed for a role via quota", "role", "resource", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, err := regexp.Compile("allocator/mesos/quota/roles/(.*?)/resources/(.*?)/guarantee")
 			if err != nil {
 				log.WithFields(log.Fields{
@@ -869,12 +869,12 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				}
 				role := matches[1]
 				resource := matches[2]
-				c.(*prometheus.GaugeVec).WithLabelValues(role, resource).Set(value)
+				c.(*prometheus.GaugeVec).WithLabelValues(role, resource, hostname).Set(value)
 			}
 			return nil
 		},
 
-		gauge("master", "allocator_resources_cpus", "Number of CPUs offered or allocated", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "allocator_resources_cpus", "Number of CPUs offered or allocated", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			total, ok := m["allocator/mesos/resources/cpus/total"]
 			if !ok {
 				log.WithField("metric", "allocator/mesos/resources/cpus/total").Warn(LogErrNotFoundInMap)
@@ -884,12 +884,12 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				log.WithField("metric", "allocator/mesos/resources/cpus/offered_or_allocated").Warn(LogErrNotFoundInMap)
 			}
 
-			c.(*prometheus.GaugeVec).WithLabelValues("total").Set(total)
-			c.(*prometheus.GaugeVec).WithLabelValues("offered_or_allocated").Set(offeredOrAllocated)
+			c.(*prometheus.GaugeVec).WithLabelValues("total", hostname).Set(total)
+			c.(*prometheus.GaugeVec).WithLabelValues("offered_or_allocated", hostname).Set(offeredOrAllocated)
 			return nil
 		},
 
-		gauge("master", "allocator_resources_disk", "Allocated or offered disk space in MB", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "allocator_resources_disk", "Allocated or offered disk space in MB", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			total, ok := m["allocator/mesos/resources/disk/total"]
 			if !ok {
 				log.WithField("metric", "allocator/mesos/resources/disk/total").Warn(LogErrNotFoundInMap)
@@ -899,12 +899,12 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				log.WithField("metric", "allocator/mesos/resources/disk/offered_or_allocated").Warn(LogErrNotFoundInMap)
 			}
 
-			c.(*prometheus.GaugeVec).WithLabelValues("total").Set(total)
-			c.(*prometheus.GaugeVec).WithLabelValues("offered_or_allocated").Set(offeredOrAllocated)
+			c.(*prometheus.GaugeVec).WithLabelValues("total", hostname).Set(total)
+			c.(*prometheus.GaugeVec).WithLabelValues("offered_or_allocated", hostname).Set(offeredOrAllocated)
 			return nil
 		},
 
-		gauge("master", "allocator_resources_mem", "Allocated or offered memory in MB", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "allocator_resources_mem", "Allocated or offered memory in MB", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			total, ok := m["allocator/mesos/resources/mem/total"]
 			if !ok {
 				log.WithField("metric", "allocator/mesos/resources/mem/total").Warn(LogErrNotFoundInMap)
@@ -914,13 +914,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				log.WithField("metric", "allocator/mesos/resources/mem/offered_or_allocated").Warn(LogErrNotFoundInMap)
 			}
 
-			c.(*prometheus.GaugeVec).WithLabelValues("total").Set(total)
-			c.(*prometheus.GaugeVec).WithLabelValues("offered_or_allocated").Set(offeredOrAllocated)
+			c.(*prometheus.GaugeVec).WithLabelValues("total", hostname).Set(total)
+			c.(*prometheus.GaugeVec).WithLabelValues("offered_or_allocated", hostname).Set(offeredOrAllocated)
 			return nil
 		},
 
 		// Framework call counts (total)
-		counter("master", "framework_calls_total", "Counts of API calls per framework", "framework_name", "framework_id"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "framework_calls_total", "Counts of API calls per framework", "framework_name", "framework_id", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/calls`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -929,13 +929,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				}
 				name := matches[1]
 				id := matches[2]
-				c.(*settableCounterVec).Set(value, name, id)
+				c.(*settableCounterVec).Set(value, name, id, hostname)
 			}
 			return nil
 		},
 
 		// Framework call counts (by type)
-		counter("master", "framework_calls", "Counts of API calls per framework", "framework_name", "framework_id", "type"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "framework_calls", "Counts of API calls per framework", "framework_name", "framework_id", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/calls/(.+)`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -945,13 +945,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				name := matches[1]
 				id := matches[2]
 				typ := matches[3]
-				c.(*settableCounterVec).Set(value, name, id, typ)
+				c.(*settableCounterVec).Set(value, name, id, typ, hostname)
 			}
 			return nil
 		},
 
 		// Framework offer operation counts (total)
-		counter("master", "framework_operations_total", "Counts of offer operations per framework", "framework_name", "framework_id"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "framework_operations_total", "Counts of offer operations per framework", "framework_name", "framework_id", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/operations`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -960,13 +960,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				}
 				name := matches[1]
 				id := matches[2]
-				c.(*settableCounterVec).Set(value, name, id)
+				c.(*settableCounterVec).Set(value, name, id, hostname)
 			}
 			return nil
 		},
 
 		// Framework offer operation counts (by type)
-		counter("master", "framework_operations", "Counts of offer operations per framework", "framework_name", "framework_id", "type"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "framework_operations", "Counts of offer operations per framework", "framework_name", "framework_id", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/operations/(.+)`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -976,13 +976,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				name := matches[1]
 				id := matches[2]
 				typ := matches[3]
-				c.(*settableCounterVec).Set(value, name, id, typ)
+				c.(*settableCounterVec).Set(value, name, id, typ, hostname)
 			}
 			return nil
 		},
 
 		// Framework subscribed
-		gauge("master", "framework_subscribed", "Boolean: is this framework subscribed?", "framework_name", "framework_id"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "framework_subscribed", "Boolean: is this framework subscribed?", "framework_name", "framework_id", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/subscribed`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -991,13 +991,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				}
 				name := matches[1]
 				id := matches[2]
-				c.(*prometheus.GaugeVec).WithLabelValues(name, id).Set(value)
+				c.(*prometheus.GaugeVec).WithLabelValues(name, id, hostname).Set(value)
 			}
 			return nil
 		},
 
 		// Framework role state
-		gauge("master", "framework_suppressed", "Boolean: are offers for this role suppressed?", "framework_name", "framework_id", "role"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "framework_suppressed", "Boolean: are offers for this role suppressed?", "framework_name", "framework_id", "role", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/roles/([^/]+)/suppressed`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -1007,13 +1007,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				name := matches[1]
 				id := matches[2]
 				role := matches[3]
-				c.(*prometheus.GaugeVec).WithLabelValues(name, id, role).Set(value)
+				c.(*prometheus.GaugeVec).WithLabelValues(name, id, role, hostname).Set(value)
 			}
 			return nil
 		},
 
 		// Framework events (total)
-		counter("master", "framework_events_total", "Counts of events per framework", "framework_name", "framework_id"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "framework_events_total", "Counts of events per framework", "framework_name", "framework_id", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/events`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -1022,13 +1022,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				}
 				name := matches[1]
 				id := matches[2]
-				c.(*settableCounterVec).Set(value, name, id)
+				c.(*settableCounterVec).Set(value, name, id, hostname)
 			}
 			return nil
 		},
 
 		// Framework events (by type)
-		counter("master", "framework_events", "Counts of events per framework", "framework_name", "framework_id", "type"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "framework_events", "Counts of events per framework", "framework_name", "framework_id", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/events/([^/]+)`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -1038,13 +1038,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				name := matches[1]
 				id := matches[2]
 				typ := matches[3]
-				c.(*settableCounterVec).Set(value, name, id, typ)
+				c.(*settableCounterVec).Set(value, name, id, typ, hostname)
 			}
 			return nil
 		},
 
 		// Framework update events (by state)
-		counter("master", "framework_update_events", "Counts of update events per framework", "framework_name", "framework_id", "state"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "framework_update_events", "Counts of update events per framework", "framework_name", "framework_id", "state", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/events/update/(.+)`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -1054,13 +1054,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				name := matches[1]
 				id := matches[2]
 				state := matches[3]
-				c.(*settableCounterVec).Set(value, name, id, state)
+				c.(*settableCounterVec).Set(value, name, id, state, hostname)
 			}
 			return nil
 		},
 
 		// Framework task active states
-		gauge("master", "framework_task_states", "Task states per framework", "framework_name", "framework_id", "state"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "framework_task_states", "Task states per framework", "framework_name", "framework_id", "state", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/tasks/([^/]+ing|task_lost)`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -1071,13 +1071,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				id := matches[2]
 				state := matches[3]
 
-				c.(*prometheus.GaugeVec).WithLabelValues(name, id, state).Set(value)
+				c.(*prometheus.GaugeVec).WithLabelValues(name, id, state, hostname).Set(value)
 			}
 			return nil
 		},
 
 		// Framework terminal task states
-		counter("master", "framework_terminal_task_states", "Terminal task states per framework", "framework_name", "framework_id", "state"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "framework_terminal_task_states", "Terminal task states per framework", "framework_name", "framework_id", "state", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			// TODO: don't use two regexes here
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/tasks/([^/]+)`)
 			notre, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/tasks/([^/]+ing|task_lost)`)
@@ -1092,13 +1092,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				id := matches[2]
 				state := matches[3]
 
-				c.(*settableCounterVec).Set(value, name, id, state)
+				c.(*settableCounterVec).Set(value, name, id, state, hostname)
 			}
 			return nil
 		},
 
 		// Framework task failures by source reason
-		counter("master", "framework_task_failures", "Framework task failures by source reason", "framework_name", "framework_id", "source", "reason"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "framework_task_failures", "Framework task failures by source reason", "framework_name", "framework_id", "source", "reason", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/tasks/task_failed/([^/]+)/([^/]+)`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -1110,13 +1110,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				source := matches[3]
 				reason := matches[4]
 
-				c.(*settableCounterVec).Set(value, name, id, source, reason)
+				c.(*settableCounterVec).Set(value, name, id, source, reason, hostname)
 			}
 			return nil
 		},
 
 		// Framework offers
-		counter("master", "framework_offers", "Number of offers by type per framework", "framework_name", "framework_id", "type"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "framework_offers", "Number of offers by type per framework", "framework_name", "framework_id", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/offers/(.+)`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -1126,13 +1126,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				name := matches[1]
 				id := matches[2]
 				typ := matches[3]
-				c.(*settableCounterVec).Set(value, name, id, typ)
+				c.(*settableCounterVec).Set(value, name, id, typ, hostname)
 			}
 			return nil
 		},
 
 		// Per-framework resource allocation: offer filters
-		counter("master", "framework_offer_filters", "Number of filters set per framework over period", "framework_name", "framework_id", "period"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "framework_offer_filters", "Number of filters set per framework over period", "framework_name", "framework_id", "period", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/allocation/offer_filters/refused_seconds/(.+)`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -1142,13 +1142,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				name := matches[1]
 				id := matches[2]
 				pd := matches[3]
-				c.(*settableCounterVec).Set(value, name, id, pd)
+				c.(*settableCounterVec).Set(value, name, id, pd, hostname)
 			}
 			return nil
 		},
 
 		// Per-framework resource filters
-		counter("master", "framework_resource_filters", "Number of times resources were filtered per framework", "framework_name", "framework_id", "reason"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "framework_resource_filters", "Number of times resources were filtered per framework", "framework_name", "framework_id", "reason", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/allocation/resources_filtered/(.+)`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -1158,13 +1158,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				name := matches[1]
 				id := matches[2]
 				reason := matches[3]
-				c.(*settableCounterVec).Set(value, name, id, reason)
+				c.(*settableCounterVec).Set(value, name, id, reason, hostname)
 			}
 			return nil
 		},
 
 		// Latest per-role DRF position
-		gauge("master", "frameworks_drf_position", "Latest per-role DRF position", "framework_name", "framework_id", "role", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("master", "frameworks_drf_position", "Latest per-role DRF position", "framework_name", "framework_id", "role", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, _ := regexp.Compile(`master/frameworks/([^.]*)\.([^/]+)/allocation/roles/([^/]+)/latest_position/(.+)`)
 			for metric, value := range m {
 				matches := re.FindStringSubmatch(metric)
@@ -1175,13 +1175,13 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				id := matches[2]
 				role := matches[3]
 				typ := matches[4]
-				c.(*prometheus.GaugeVec).WithLabelValues(name, id, role, typ).Set(value)
+				c.(*prometheus.GaugeVec).WithLabelValues(name, id, role, typ, hostname).Set(value)
 			}
 			return nil
 		},
 
 		// Framework message metrics
-		counter("master", "frameworks_messages", "Messages passed around with the frameworks", "framework", "type"): func(m metricMap, c prometheus.Collector) error {
+		counter("master", "frameworks_messages", "Messages passed around with the frameworks", "framework", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			re, err := regexp.Compile("frameworks/(.*?)/messages_(.*?)$")
 			if err != nil {
 				log.WithFields(log.Fields{
@@ -1199,53 +1199,53 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 				framework := matches[1]
 				messageStatus := matches[2]
 				if len(framework) > 0 && len(messageStatus) > 0 {
-					c.(*settableCounterVec).Set(messageCount, framework, messageStatus)
+					c.(*settableCounterVec).Set(messageCount, framework, messageStatus, hostname)
 				}
 			}
 			return nil
 		},
 
 		// Registrar stats
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "registrar",
 			Name:      "registry_size_bytes",
 			Help:      "Size of the registry in bytes",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			size, ok := m["registrar/registry_size_bytes"]
 			if !ok {
 				log.WithField("metric", "registrar/registry_size_bytes").Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(size)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(size)
 			return nil
 		},
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "registrar",
 			Name:      "queued_operations",
 			Help:      "Number of operations in the registry queue",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			ops, ok := m["registrar/queued_operations"]
 			if !ok {
 				log.WithField("metric", "registrar/queued_operations").Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(ops)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(ops)
 			return nil
 		},
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "registrar",
 			Name:      "state_fetch_ms",
 			Help:      "Duration of state JSON fetch in ms",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			ms, ok := m["registrar/state_fetch_ms"]
 			if !ok {
 				log.WithField("metric", "registrar/state_fetch_ms").Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(ms)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(ms)
 			return nil
 		},
-		gauge("registrar", "state_store_ms", "Duration of state json store in ms.", "type"): func(m metricMap, c prometheus.Collector) error {
+		gauge("registrar", "state_store_ms", "Duration of state json store in ms.", "type", "hostname"): func(m metricMap, c prometheus.Collector) error {
 			mean, ok := m["registrar/state_store_ms"]
 			if !ok {
 				log.WithFields(log.Fields{
@@ -1300,71 +1300,71 @@ func newMasterCollector(httpClient *httpClient) prometheus.Collector {
 					"name": "registrar/state_store_ms/p9999",
 				}).Warn(LogErrNotFoundInMap)
 			}
-			c.(*prometheus.GaugeVec).WithLabelValues("mean").Set(mean)
-			c.(*prometheus.GaugeVec).WithLabelValues("min").Set(min)
-			c.(*prometheus.GaugeVec).WithLabelValues("max").Set(max)
-			c.(*prometheus.GaugeVec).WithLabelValues("p50").Set(p50)
-			c.(*prometheus.GaugeVec).WithLabelValues("p90").Set(p90)
-			c.(*prometheus.GaugeVec).WithLabelValues("p95").Set(p95)
-			c.(*prometheus.GaugeVec).WithLabelValues("p99").Set(p99)
-			c.(*prometheus.GaugeVec).WithLabelValues("p999").Set(p999)
-			c.(*prometheus.GaugeVec).WithLabelValues("p9999").Set(p9999)
+			c.(*prometheus.GaugeVec).WithLabelValues("mean", hostname).Set(mean)
+			c.(*prometheus.GaugeVec).WithLabelValues("min", hostname).Set(min)
+			c.(*prometheus.GaugeVec).WithLabelValues("max", hostname).Set(max)
+			c.(*prometheus.GaugeVec).WithLabelValues("p50", hostname).Set(p50)
+			c.(*prometheus.GaugeVec).WithLabelValues("p90", hostname).Set(p90)
+			c.(*prometheus.GaugeVec).WithLabelValues("p95", hostname).Set(p95)
+			c.(*prometheus.GaugeVec).WithLabelValues("p99", hostname).Set(p99)
+			c.(*prometheus.GaugeVec).WithLabelValues("p999", hostname).Set(p999)
+			c.(*prometheus.GaugeVec).WithLabelValues("p9999", hostname).Set(p9999)
 			return nil
 		},
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "registrar",
 			Name:      "log_recovered",
 			Help:      "Recovered status of the registrar log",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			recovered, ok := m["registrar/log/recovered"]
 			if !ok {
 				log.WithField("metric", "registrar/log/recovered").Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(recovered)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(recovered)
 			return nil
 		},
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "registrar",
 			Name:      "log_ensemble_size",
 			Help:      "Ensemble size of the registrar log",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			size, ok := m["registrar/log/ensemble_size"]
 			if !ok {
 				log.WithField("metric", "registrar/log/ensemble_size").Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(size)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(size)
 			return nil
 		},
 
 		// Overlay log
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "overlay",
 			Name:      "log_recovered",
 			Help:      "Recovered status of the overlay log",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			recovered, ok := m["overlay/log/recovered"]
 			if !ok {
 				log.WithField("metric", "overlay/log/recovered").Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(recovered)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(recovered)
 			return nil
 		},
-		prometheus.NewGauge(prometheus.GaugeOpts{
+		prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "mesos",
 			Subsystem: "overlay",
 			Name:      "log_ensemble_size",
 			Help:      "Ensemble size of the overlay log",
-		}): func(m metricMap, c prometheus.Collector) error {
+		}, []string{"hostname"}): func(m metricMap, c prometheus.Collector) error {
 			size, ok := m["overlay/log/ensemble_size"]
 			if !ok {
 				log.WithFields(log.Fields{
 					"name": "overlay/log_ensemble_size",
 				}).Warn(LogErrNotFoundInMap)
 			}
-			c.(prometheus.Gauge).Set(size)
+			c.(*prometheus.GaugeVec).WithLabelValues(hostname).Set(size)
 			return nil
 		},
 


### PR DESCRIPTION
Example output (filtering out the Descs):
```
mesos_master_allocation_run_latency_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="mean"} 0.011008
mesos_master_allocation_run_latency_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="min"} 0.007168
mesos_master_allocation_run_latency_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p50"} 0.011776
mesos_master_allocation_run_latency_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p90"} 0.013056
mesos_master_allocation_run_latency_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p95"} 0.01408
mesos_master_allocation_run_latency_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p99"} 0.01796096
mesos_master_allocation_run_latency_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p999"} 0.0409699839999998
mesos_master_allocation_run_latency_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p9999"} 0.0499465984000007
mesos_master_allocation_run_latency_ms_count{event="allocation",hostname="ip-10-0-6-97.us-west-2.compute.internal"} 1000
mesos_master_allocation_run_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="max"} 0.240128
mesos_master_allocation_run_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="mean"} 0.131072
mesos_master_allocation_run_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="min"} 0.103936
mesos_master_allocation_run_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p50"} 0.132096
mesos_master_allocation_run_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p90"} 0.155136
mesos_master_allocation_run_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p95"} 0.163072
mesos_master_allocation_run_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p99"} 0.19789824
mesos_master_allocation_run_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p999"} 0.231944192
mesos_master_allocation_run_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p9999"} 0.239309619200001
mesos_master_allocation_run_ms_count{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 22754
mesos_master_allocation_runs{event="allocation",hostname="ip-10-0-6-97.us-west-2.compute.internal"} 22754
mesos_master_allocator_event_queue_dispatches{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_master_allocator_offer_filters_active{hostname="ip-10-0-6-97.us-west-2.compute.internal",role="*"} 1
mesos_master_allocator_offer_filters_active{hostname="ip-10-0-6-97.us-west-2.compute.internal",role="slave_public"} 1
mesos_master_allocator_resources_cpus{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="offered_or_allocated"} 0
mesos_master_allocator_resources_cpus{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="total"} 4
mesos_master_allocator_resources_disk{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="offered_or_allocated"} 0
mesos_master_allocator_resources_disk{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="total"} 138004
mesos_master_allocator_resources_mem{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="offered_or_allocated"} 0
mesos_master_allocator_resources_mem{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="total"} 15026
mesos_master_allocator_role_shares_dominant{hostname="ip-10-0-6-97.us-west-2.compute.internal",role="*"} 0
mesos_master_allocator_role_shares_dominant{hostname="ip-10-0-6-97.us-west-2.compute.internal",role="slave_public"} 0
mesos_master_cpus{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="free"} 4
mesos_master_cpus{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="percent"} 0
mesos_master_cpus{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="total"} 4
mesos_master_cpus{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="used"} 0
mesos_master_cpus_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="free"} 0
mesos_master_cpus_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="percent"} 0
mesos_master_cpus_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="total"} 0
mesos_master_cpus_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="used"} 0
mesos_master_disk{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="free"} 138004
mesos_master_disk{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="percent"} 0
mesos_master_disk{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="total"} 138004
mesos_master_disk{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="used"} 0
mesos_master_disk_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="free"} 0
mesos_master_disk_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="percent"} 0
mesos_master_disk_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="total"} 0
mesos_master_disk_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="used"} 0
mesos_master_elected{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 1
mesos_master_event_queue_dispatches{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_master_event_queue_length{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="dispatches"} 2
mesos_master_event_queue_length{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="http_request"} 0
mesos_master_event_queue_length{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="message"} 0
mesos_master_frameworks_messages{framework="dcos_marathon",hostname="ip-10-0-6-97.us-west-2.compute.internal",type="processed"} 1555
mesos_master_frameworks_messages{framework="dcos_marathon",hostname="ip-10-0-6-97.us-west-2.compute.internal",type="received"} 1555
mesos_master_frameworks_messages{framework="dcos_metronome",hostname="ip-10-0-6-97.us-west-2.compute.internal",type="processed"} 212
mesos_master_frameworks_messages{framework="dcos_metronome",hostname="ip-10-0-6-97.us-west-2.compute.internal",type="received"} 212
mesos_master_frameworks_state{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="connected_active"} 2
mesos_master_frameworks_state{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="connected_inactive"} 0
mesos_master_frameworks_state{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="disconnected_inactive"} 0
mesos_master_gpus{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="free"} 0
mesos_master_gpus{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="percent"} 0
mesos_master_gpus{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="total"} 0
mesos_master_gpus{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="used"} 0
mesos_master_gpus_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="free"} 0
mesos_master_gpus_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="percent"} 0
mesos_master_gpus_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="total"} 0
mesos_master_gpus_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="used"} 0
mesos_master_mem{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="free"} 15026
mesos_master_mem{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="percent"} 0
mesos_master_mem{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="total"} 15026
mesos_master_mem{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="used"} 0
mesos_master_mem_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="free"} 0
mesos_master_mem_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="percent"} 0
mesos_master_mem_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="total"} 0
mesos_master_mem_revocable{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="used"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="authenticate_messages"} 3
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="deactivate_framework"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="decline_offers"} 265
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="dropped_messages"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="executor_to_framework"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="exited_executor"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="framework_to_executor"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="kill_task"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="launch_tasks"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="reconcile_tasks"} 1499
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="register_framework"} 2
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="register_slave"} 1
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="reregister_framework"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="reregister_slave"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="resource_request"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="revive_offers"} 3
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="status_update"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="status_update_acknowledgement"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="suppress_offers"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="unregister_framework"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="unregister_slave"} 0
mesos_master_messages{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="update_slave"} 1
mesos_master_messages_outcomes_total{destination="executor",hostname="ip-10-0-6-97.us-west-2.compute.internal",outcome="invalid",source="framework",type=""} 0
mesos_master_messages_outcomes_total{destination="executor",hostname="ip-10-0-6-97.us-west-2.compute.internal",outcome="valid",source="framework",type=""} 0
mesos_master_messages_outcomes_total{destination="framework",hostname="ip-10-0-6-97.us-west-2.compute.internal",outcome="invalid",source="executor",type=""} 0
mesos_master_messages_outcomes_total{destination="framework",hostname="ip-10-0-6-97.us-west-2.compute.internal",outcome="invalid",source="slave",type="status_update"} 0
mesos_master_messages_outcomes_total{destination="framework",hostname="ip-10-0-6-97.us-west-2.compute.internal",outcome="valid",source="executor",type=""} 0
mesos_master_messages_outcomes_total{destination="framework",hostname="ip-10-0-6-97.us-west-2.compute.internal",outcome="valid",source="slave",type="status_update"} 0
mesos_master_messages_outcomes_total{destination="slave",hostname="ip-10-0-6-97.us-west-2.compute.internal",outcome="invalid",source="framework",type="status_update"} 0
mesos_master_messages_outcomes_total{destination="slave",hostname="ip-10-0-6-97.us-west-2.compute.internal",outcome="valid",source="framework",type="status_update"} 0
mesos_master_offers_pending{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_master_recovery_slave_removal_events_total{event="removal",hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_master_slave_registration_events_total{event="register",hostname="ip-10-0-6-97.us-west-2.compute.internal"} 1
mesos_master_slave_registration_events_total{event="reregister",hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_master_slave_removal_events_reasons{hostname="ip-10-0-6-97.us-west-2.compute.internal",reason="registered"} 0
mesos_master_slave_removal_events_reasons{hostname="ip-10-0-6-97.us-west-2.compute.internal",reason="unhealthy"} 0
mesos_master_slave_removal_events_reasons{hostname="ip-10-0-6-97.us-west-2.compute.internal",reason="unregistered"} 0
mesos_master_slave_removal_events_total{event="canceled",hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_master_slave_removal_events_total{event="completed",hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_master_slave_removal_events_total{event="died",hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_master_slave_removal_events_total{event="scheduled",hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_master_slave_unreachable_events_total{event="canceled",hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_master_slave_unreachable_events_total{event="completed",hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_master_slave_unreachable_events_total{event="scheduled",hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_master_slaves_state{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="connected_active"} 1
mesos_master_slaves_state{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="connected_inactive"} 0
mesos_master_slaves_state{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="disconnected_inactive"} 0
mesos_master_slaves_state{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="unreachable"} 0
mesos_master_task_states_current{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="running"} 0
mesos_master_task_states_current{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="staging"} 0
mesos_master_task_states_current{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="starting"} 0
mesos_master_task_states_current{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="unreachable"} 0
mesos_master_task_states_exit_total{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="dropped"} 0
mesos_master_task_states_exit_total{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="errored"} 0
mesos_master_task_states_exit_total{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="failed"} 0
mesos_master_task_states_exit_total{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="finished"} 0
mesos_master_task_states_exit_total{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="gone"} 0
mesos_master_task_states_exit_total{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="gone_by_operator"} 0
mesos_master_task_states_exit_total{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="killed"} 0
mesos_master_task_states_exit_total{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="killing"} 0
mesos_master_task_states_exit_total{hostname="ip-10-0-6-97.us-west-2.compute.internal",state="lost"} 0
mesos_master_uptime_seconds{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 22766.873231104
mesos_overlay_log_ensemble_size{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 1
mesos_overlay_log_recovered{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 1
mesos_registrar_log_ensemble_size{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 1
mesos_registrar_log_recovered{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 1
mesos_registrar_queued_operations{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 0
mesos_registrar_registry_size_bytes{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 408
mesos_registrar_state_fetch_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal"} 20.161024
mesos_registrar_state_store_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="max"} 6.902016
mesos_registrar_state_store_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="mean"} 4.739072
mesos_registrar_state_store_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="min"} 4.739072
mesos_registrar_state_store_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p50"} 5.820544
mesos_registrar_state_store_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p90"} 6.6857216
mesos_registrar_state_store_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p95"} 6.7938688
mesos_registrar_state_store_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p99"} 6.88038656
mesos_registrar_state_store_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p999"} 6.899853056
mesos_registrar_state_store_ms{hostname="ip-10-0-6-97.us-west-2.compute.internal",type="p9999"} 6.9017997056
```