### PR TITLE
Prototype for adding Prometheus service discovery

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,11 +230,49 @@ func main() {
             <body>
             <h1>Mesos Exporter</h1>
             <p><a href="/metrics">Metrics</a></p>
+	    <p><a href="/sd">Slave service discovery</a></p>
             </body>
             </html>`))
 	})
 	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/sd", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(SDMesosSlaves(*masterURL)))
 	if err := http.ListenAndServe(*addr, nil); err != nil {
 		log.WithField("error", err).Fatal("listen and serve error")
 	}
 }
+func SDMesosSlaves(url string)(out string){
+	url = url  + "/state"
+	request, err := http.NewRequest("GET",url,nil)
+	client := http.Client{}
+        resp, err := client.Do(request)
+        if err != nil {
+		fmt.Printf("Cannot get to Mesos API\n")
+		return "null"
+        }
+	body, err := ioutil.ReadAll(resp.Body)
+	if resp != nil {
+		return ParseMesos(string(body))
+	} else {
+		return "null"
+	}
+}
+
+func ParseMesos(body string) (computed string) {
+	cadvisor_port, present := os.LookupEnv("CADVISOR_PORT")
+	if !present {
+		cadvisor_port = "8888"
+	}
+	labels := os.Getenv("LABELS")
+        computed = "[{\"targets\": ["
+        result := gjson.Get(string(body), "slaves.#.hostname")
+        list := ""
+	if result.Exists() {
+		for _,name := range result.Array() {
+			list = list + fmt.Sprintf("\"%s:%s\",",name.String(), cadvisor_port)
+		}
+ 	}
+
+        computed = computed + fmt.Sprintf("%s], \"labels\": { %s } } ]", strings.TrimSuffix(list,","),labels)
+        return computed
+ }


### PR DESCRIPTION
I think it could be useful for others having a Prometheus Service Discovery endpoint.
The idea behind is having an output ready to be used for Prometheus (https://www.robustperception.io/using-json-file-service-discovery-with-prometheus/); in such a way if the cluster has dynamic members joining, you can have them monitored with no human intervention. All you need is periodically poll this exporter ( on all masters), save on file if the output is not 'null' and configure Prometheus to reads this file. 
THIS IS A PROTOTYPE to start a discussion about this enhancement, 
it needs to modified in order to :
* written in nice Golang :)
* use any json library instead of creating a string 
* use command line arguments instead of Environment variables
* decide what to do on a slave
* have some testing code
* have the related code outside the main file